### PR TITLE
V1.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 dist/
 node_modules/
+playwright-profiles/
+test-results/
+playwright-report/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ Copy-n-Paste: Clipboard Upload Simplified is a lightweight extension for Chromiu
 4. Select the extracted extension folder
 <br><br>
 
+## Testing
+Run local extension smoke tests:
+
+```sh
+npm run build
+npm run test:smoke
+```
+
+Run authenticated real-site checks (Example for Google Contacts, LinkedIn):
+
+```sh
+npm run build
+npm run diagnose:sites -- contacts linkedin
+npm run test:sites
+```
+
+The real-site tests reuse `playwright-profiles/real-sites`. Log in manually through `diagnose:sites` first, then keep `CNP_BROWSER_CHANNEL` empty when running Chromium extension diagnostics/tests so the unpacked extension can load.
+
+To run one real-site target:
+
+```powershell
+$env:CNP_SITE_TARGETS='linkedin'; npm run test:sites; Remove-Item Env:CNP_SITE_TARGETS -ErrorAction SilentlyContinue
+```
+<br><br>
+
 ## Bugs and Feature requests
 Please first check for [existing and closed issues](https://github.com/kazcfz/Paste-Image-Uploader/issues?q=is%3Aissue).<br>
 If it's new, please [create a new issue](https://github.com/kazcfz/Paste-Image-Uploader/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -68,28 +68,7 @@ Copy-n-Paste: Clipboard Upload Simplified is a lightweight extension for Chromiu
 <br><br>
 
 ## Testing
-Run local extension smoke tests:
-
-```sh
-npm run build
-npm run test:smoke
-```
-
-Run authenticated real-site checks (Example for Google Contacts, LinkedIn):
-
-```sh
-npm run build
-npm run diagnose:sites -- contacts linkedin
-npm run test:sites
-```
-
-The real-site tests reuse `playwright-profiles/real-sites`. Log in manually through `diagnose:sites` first, then keep `CNP_BROWSER_CHANNEL` empty when running Chromium extension diagnostics/tests so the unpacked extension can load.
-
-To run one real-site target:
-
-```powershell
-$env:CNP_SITE_TARGETS='linkedin'; npm run test:sites; Remove-Item Env:CNP_SITE_TARGETS -ErrorAction SilentlyContinue
-```
+Testing instructions for local smoke checks, authenticated real-site validation, and manual diagnostics are in [TESTING.md](TESTING.md).
 <br><br>
 
 ## Bugs and Feature requests

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,77 @@
+# Testing
+
+## Local smoke tests
+
+Run the local extension smoke suite:
+
+```sh
+npm run build
+npm run test:smoke
+```
+
+This covers the extension overlay against local fixtures, including direct file inputs, picker proxies, drag-and-drop targets, and pickerless upload buttons.
+
+## Authenticated real-site tests
+
+Run authenticated real-site checks after building the extension:
+
+```sh
+npm run build
+npm run test:sites
+```
+
+The real-site suite reuses `playwright-profiles/real-sites`, so log in once and keep that profile for subsequent runs.
+
+Current real-site targets include:
+
+- Google Contacts
+- LinkedIn
+- Bluesky
+- Gemini
+
+To limit the run to one or more targets:
+
+```powershell
+$env:CNP_SITE_TARGETS='bsky,gemini'; npm run test:sites; Remove-Item Env:CNP_SITE_TARGETS -ErrorAction SilentlyContinue
+```
+
+Keep `CNP_BROWSER_CHANNEL` empty when running Chromium extension tests so the unpacked extension can load:
+
+```powershell
+$env:CNP_BROWSER_CHANNEL=''; npm run test:sites; Remove-Item Env:CNP_BROWSER_CHANNEL -ErrorAction SilentlyContinue
+```
+
+## Manual diagnostics
+
+Use the headed diagnostic browser when a live site diverges from the local smoke fixtures:
+
+```powershell
+$env:CNP_BROWSER_CHANNEL=''; npm run diagnose:sites -- bsky gemini; Remove-Item Env:CNP_BROWSER_CHANNEL -ErrorAction SilentlyContinue
+```
+
+This opens the persistent Playwright profile and logs:
+
+- manual click steps
+- file input creation and activation
+- overlay upload activation events
+- upload-related UI add/remove events
+
+## Native picker diagnostics
+
+By default, Playwright can intercept chooser events for logging. That is useful for automated diagnostics, but it can suppress the visible Windows file picker.
+
+To let the native Windows file picker appear during manual diagnostics, disable chooser interception:
+
+```powershell
+$env:CNP_BROWSER_CHANNEL=''; $env:CNP_INTERCEPT_FILE_CHOOSER='0'; npm run diagnose:sites -- bsky gemini; Remove-Item Env:CNP_BROWSER_CHANNEL -ErrorAction SilentlyContinue; Remove-Item Env:CNP_INTERCEPT_FILE_CHOOSER -ErrorAction SilentlyContinue
+```
+
+Use this mode when verifying whether clicking the overlay `Upload Files` row opens the actual OS picker.
+
+## Suggested workflow
+
+1. Run `npm run build`.
+2. Run `npm run test:smoke`.
+3. If a regression only reproduces on a live site, run `npm run diagnose:sites` and log in through the persistent profile.
+4. Run `npm run test:sites` for the affected targets.
+5. If the issue is specifically about the visible Windows picker, rerun diagnostics with `CNP_INTERCEPT_FILE_CHOOSER='0'`.

--- a/background.js
+++ b/background.js
@@ -1,6 +1,23 @@
 // Periodically listen for new version
 const interval = 150;
 const checkForUpdate = () => chrome.runtime.requestUpdateCheck(() => { });
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+	if (!message || message.Type !== 'CnP-inject-main-world')
+		return false;
+
+	if (!sender.tab || !chrome.scripting || typeof chrome.scripting.executeScript !== 'function') {
+		sendResponse({ ok: false });
+		return false;
+	}
+
+	chrome.scripting.executeScript({
+		target: { tabId: sender.tab.id, frameIds: [sender.frameId] },
+		files: ['init.js'],
+		world: 'MAIN'
+	}, () => sendResponse({ ok: !chrome.runtime.lastError }));
+
+	return true;
+});
 chrome.runtime.onUpdateAvailable.addListener(() => chrome.runtime.reload());
 chrome.runtime.onInstalled.addListener(() => chrome.alarms.create('u', { periodInMinutes: interval }));
 chrome.runtime.onStartup.addListener(() => chrome.alarms.create('u', { periodInMinutes: interval }));

--- a/content.js
+++ b/content.js
@@ -173,6 +173,40 @@ function isPageFileInput(node) {
     return node && node.matches && node.matches("input[type='file']") && node.id !== 'cnp-overlay-file-input' && !node.id.toLowerCase().startsWith('cnp');
 }
 
+function uploadSurfaceText(element) {
+    if (!element || !element.getAttribute)
+        return '';
+
+    return [
+        element.id,
+        element.getAttribute('class'),
+        element.getAttribute('aria-label'),
+        element.getAttribute('title'),
+        element.getAttribute('name'),
+        element.getAttribute('data-testid'),
+        element.getAttribute('data-test-id'),
+        element.getAttribute('role'),
+        (element.innerText || element.textContent || '').slice(0, 200)
+    ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
+}
+
+function ignoredUploadSurfaceText(element) {
+    if (!element || !element.getAttribute)
+        return '';
+
+    return [
+        element.getAttribute('aria-label'),
+        element.getAttribute('title'),
+        element.getAttribute('name'),
+        element.getAttribute('role'),
+        (element.innerText || element.textContent || '').slice(0, 200)
+    ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
+}
+
+function isIgnoredUploadSurface(element) {
+    return /\bmeta\s+ai\s+business\s+assistant\b|\bmeta\s+ai\b/i.test(ignoredUploadSurfaceText(element));
+}
+
 function hasActiveUserGesture() {
     return !navigator.userActivation || navigator.userActivation.isActive;
 }
@@ -180,6 +214,16 @@ function hasActiveUserGesture() {
 function hasRecentPageActivation(fileInput) {
     const activatedAt = Number(fileInput.dataset.cnpPageActivation || 0);
     return activatedAt > 0 && Date.now() - activatedAt < 1000;
+}
+
+function hasRecentSuppressedFileActivation(fileInput) {
+    const inputSuppressedAt = Number(fileInput.dataset.cnpSuppressNextFileActivation || 0);
+    const documentSuppressedAt = Number(document.documentElement.dataset.cnpSuppressFileActivation || 0);
+    return Date.now() - Math.max(inputSuppressedAt, documentSuppressedAt) < 1500;
+}
+
+function hasRecentPickerlessHandoff() {
+    return Date.now() - Number(document.documentElement.dataset.cnpPickerlessHandoff || 0) < 1500;
 }
 
 function findClickedFileInput(event) {
@@ -235,8 +279,28 @@ function installFileInputActivationListeners() {
 
     document.addEventListener("click", event => {
         const fileInput = findClickedFileInput(event);
-        if (fileInput)
-            openOverlayFromCapturedClick(event, fileInput);
+        if (!fileInput)
+            return;
+
+        if (event.isTrusted === false && hasRecentSuppressedFileActivation(fileInput)) {
+            if (event.cancelable !== false)
+                event.preventDefault();
+            event.stopPropagation();
+            if (typeof event.stopImmediatePropagation === 'function')
+                event.stopImmediatePropagation();
+            return;
+        }
+
+        if (event.isTrusted === false && hasRecentPickerlessHandoff())
+            return;
+
+        if (event.isTrusted === false && !hasRecentPageActivation(fileInput) && !hasActiveUserGesture())
+            return;
+
+        if (fileInput.dataset.cnpNativePickerBypass && Date.now() - Number(fileInput.dataset.cnpNativePickerBypass) < 1500)
+            return;
+
+        openOverlayFromCapturedClick(event, fileInput);
     }, true);
 }
 

--- a/content.js
+++ b/content.js
@@ -119,54 +119,132 @@ function fetchAndInjectScript(targetDoc, scriptPath, id, attrs) {
     }
 }
 
-// Inject init.js to the DOM: use extension URL for Google Docs/Slides (their CSP blocks blob:),
-// otherwise use blob injection to avoid TrustedScriptURL enforcement on other pages.
-if (!document.head.querySelector('CnP-init')) {
+function injectInitScriptTag() {
+    if (document.getElementById('CnP-init') || document.documentElement.dataset.cnpPageHookLoaded)
+        return;
+
     const initJS = document.createElement('script');
     initJS.id = `CnP-init`;
     initJS.setAttribute('overlayhtml', safeGetURL('overlay.html'));
 
-    const isGoogleDocs = (location.hostname || '').includes('docs.google') || (location.hostname || '').includes('slides.google');
-    if (isGoogleDocs) {
-        // Docs blocks blob:, but may allow extension's chrome-extension:// URL (depends on installed extension id)
-        try { initJS.setAttribute('src', safeGetURL('init.js')); } catch (e) { initJS.src = safeGetURL('init.js') }
-        document.head.appendChild(initJS);
-    } else {
-        // Try to fetch the extension script and inject via blob URL
-        try {
-            fetch(safeGetURL('init.js'))
-                .then(response => response.text())
-                .then(code => {
-                    try {
-                        const blob = new Blob([code], { type: 'text/javascript' });
-                        const blobUrl = URL.createObjectURL(blob);
-                        initJS.setAttribute('src', blobUrl);
-                    } catch (e) {
-                        // fallback to direct extension URL
-                        try { initJS.setAttribute('src', safeGetURL('init.js')); } catch (e2) { initJS.src = safeGetURL('init.js') }
-                    }
-                    document.head.appendChild(initJS);
-                })
-                .catch(err => {
-                    // Fallback: append script with extension URL
-                    try { initJS.setAttribute('src', safeGetURL('init.js')); } catch (e) { initJS.src = safeGetURL('init.js') }
-                    document.head.appendChild(initJS);
-                });
-        } catch (e) {
-            try { initJS.setAttribute('src', safeGetURL('init.js')); } catch (e2) { initJS.src = safeGetURL('init.js') }
-            document.head.appendChild(initJS);
-        }
-    }
+    try { initJS.setAttribute('src', safeGetURL('init.js')); } catch (e) { initJS.src = safeGetURL('init.js') }
+    const scriptParent = document.head || document.documentElement;
+    if (scriptParent)
+        scriptParent.appendChild(initJS);
 }
+
+function requestMainWorldInit() {
+    return new Promise(resolve => {
+        try {
+            if (document.documentElement.dataset.cnpPageHookLoaded) {
+                resolve(true);
+                return;
+            }
+
+            if (typeof chrome === 'undefined' || !chrome.runtime || typeof chrome.runtime.sendMessage !== 'function') {
+                resolve(false);
+                return;
+            }
+
+            chrome.runtime.sendMessage({ Type: 'CnP-inject-main-world' }, response => {
+                try {
+                    if (chrome.runtime.lastError)
+                        resolve(false);
+                    else
+                        resolve(!!(response && response.ok));
+                } catch (e) { resolve(false) }
+            });
+        } catch (e) { resolve(false) }
+    });
+}
+
+// Inject init.js into the page world as early as possible. Chromium uses
+// chrome.scripting for MAIN-world injection; Firefox and fallback paths use a
+// script tag when the page hook marker is still missing.
+requestMainWorldInit().then(ok => {
+    const fallbackDelay = ok ? 100 : 0;
+    setTimeout(() => {
+        if (!document.documentElement.dataset.cnpPageHookLoaded)
+            injectInitScriptTag();
+    }, fallbackDelay);
+});
+
+function isPageFileInput(node) {
+    return node && node.matches && node.matches("input[type='file']") && node.id !== 'cnp-overlay-file-input' && !node.id.toLowerCase().startsWith('cnp');
+}
+
+function hasActiveUserGesture() {
+    return !navigator.userActivation || navigator.userActivation.isActive;
+}
+
+function hasRecentPageActivation(fileInput) {
+    const activatedAt = Number(fileInput.dataset.cnpPageActivation || 0);
+    return activatedAt > 0 && Date.now() - activatedAt < 1000;
+}
+
+function findClickedFileInput(event) {
+    const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
+    const pathInput = path.find(node => isPageFileInput(node));
+    if (pathInput)
+        return pathInput;
+
+    const label = path.find(node => node && node.tagName === 'LABEL');
+    if (!label)
+        return null;
+
+    if (isPageFileInput(label.control))
+        return label.control;
+
+    if (label.querySelector) {
+        const nestedInput = label.querySelector("input[type='file']");
+        if (isPageFileInput(nestedInput))
+            return nestedInput;
+    }
+
+    return null;
+}
+
+function openOverlayFromCapturedClick(event, fileInput) {
+    setupcreateOverlay(fileInput);
+    createOverlay({
+        target: fileInput,
+        preventDefault: () => {
+            if (event.cancelable !== false)
+                event.preventDefault();
+        },
+        stopPropagation: () => {
+            event.stopPropagation();
+            if (typeof event.stopImmediatePropagation === 'function')
+                event.stopImmediatePropagation();
+        }
+    });
+}
+
+function installFileInputActivationListeners() {
+    if (document.cnpFileInputActivationListeners)
+        return;
+
+    document.cnpFileInputActivationListeners = true;
+    document.addEventListener('cnp-page-file-input-activated', event => {
+        const fileInput = isPageFileInput(event.target) ? event.target : null;
+        if (!fileInput || !hasRecentPageActivation(fileInput) || !hasActiveUserGesture())
+            return;
+
+        openOverlayFromCapturedClick(event, fileInput);
+    }, true);
+
+    document.addEventListener("click", event => {
+        const fileInput = findClickedFileInput(event);
+        if (fileInput)
+            openOverlayFromCapturedClick(event, fileInput);
+    }, true);
+}
+
+installFileInputActivationListeners();
 
 function afterDOMLoaded() {
     // Prep all input file elements
-    if (!document.cnpClickListener)
-        document.addEventListener("click", event => {
-            document.cnpClickListener = true;
-            if (event.target.matches("input[type='file']"))
-                setupcreateOverlay(event.target);
-        }, true);
+    installFileInputActivationListeners();
 
     // Run through DOM to detect:
     document.querySelectorAll('*').forEach((element, index) => {
@@ -210,25 +288,26 @@ function afterDOMLoaded() {
                     }
 
                     // iframes
-                    else if (node.nodeType === Node.ELEMENT_NODE && node.matches("iframe"))
+                    else if (node.nodeType === Node.ELEMENT_NODE && node.matches("iframe")) {
                         if (node.contentDocument) {
                             // Inject scripts into dynamically added iframe using blob URLs
                             node.classList.add(`CnP-mutatedIframe-${index}`);
                             fetchAndInjectScript(node.contentDocument, 'init.js', `CnP-init-iframe-${index}`);
                             fetchAndInjectScript(node.contentDocument, 'content.js', `CnP-mutatedIframe-${index}`, { overlayhtml: safeGetURL('overlay.html') });
                         }
+                    }
 
-                        // Checks if sub-nodes/child are input file elements
-                        else if (node.nodeType === Node.ELEMENT_NODE && node.hasChildNodes())
-                            node.querySelectorAll("input[type='file']").forEach(fileInput => setupcreateOverlay(fileInput));
+                    // Checks if sub-nodes/child are input file elements
+                    else if (node.nodeType === Node.ELEMENT_NODE && node.hasChildNodes())
+                        node.querySelectorAll("input[type='file']").forEach(fileInput => setupcreateOverlay(fileInput));
 
-                        // If the added node is a document fragment, it may contain shadow hosts
-                        else if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-                            node.childNodes.forEach(childNode => {
-                                if (childNode.nodeType === Node.ELEMENT_NODE && childNode.shadowRoot)
-                                    childNode.shadowRoot.querySelectorAll("input[type='file']").forEach(fileInput => setupcreateOverlay(fileInput));
-                            });
-                        }
+                    // If the added node is a document fragment, it may contain shadow hosts
+                    else if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+                        node.childNodes.forEach(childNode => {
+                            if (childNode.nodeType === Node.ELEMENT_NODE && childNode.shadowRoot)
+                                childNode.shadowRoot.querySelectorAll("input[type='file']").forEach(fileInput => setupcreateOverlay(fileInput));
+                        });
+                    }
                 });
             });
         });
@@ -237,40 +316,4 @@ function afterDOMLoaded() {
             document.body.cnpMutationObserver = true;
         } catch (error) { logging(error) }
     }
-
-    // Message listener between window.top and iframes
-    if (!window.cnpMessageListener)
-        window.addEventListener('message', event => {
-            window.cnpMessageListener = true;
-            // Execute paste events from top level since iframes can't
-            if (event.data.Type == 'paste') {
-                if (!event.data.iframe)
-                    document.execCommand('paste');
-                else {
-                    try {
-                        let el = null;
-                        // event.data.iframe may be an id or a class — try id first
-                        try { el = document.getElementById(event.data.iframe) || document.getElementsByClassName(event.data.iframe)[0]; } catch (e) { el = null }
-                        if (el && el.contentDocument && typeof el.contentDocument.execCommand === 'function')
-                            el.contentDocument.execCommand('paste');
-                        else
-                            logging('iframe for paste not available');
-                    } catch (error) {
-                        logging(error);
-                        try { noImage() } catch (error) { logging(error) }
-                    }
-                }
-            } else if (event.data.Type == 'getURL')
-                if (event.data.iframe) {
-                    try {
-                        let el = null;
-                        try { el = document.getElementById(event.data.iframe) || document.getElementsByClassName(event.data.iframe)[0]; } catch (e) { el = null }
-                        if (el && el.contentWindow && typeof el.contentWindow.postMessage === 'function')
-                            el.contentWindow.postMessage({ 'Type': 'getURL-response', 'URL': safeGetURL(event.data.Path) }, '*');
-                        else
-                            logging('iframe for getURL not available');
-                    } catch (error) { logging(error) }
-                } else
-                    window.top.postMessage({ 'Type': 'getURL-response', 'URL': safeGetURL(event.data.Path) }, '*');
-        });
 }

--- a/content.js
+++ b/content.js
@@ -91,6 +91,17 @@ function fetchAndInjectScript(targetDoc, scriptPath, id, attrs) {
                 if (attrs) Object.keys(attrs).forEach(k => s.setAttribute(k, attrs[k]));
                 const blob = new Blob([code], { type: 'text/javascript' });
                 const blobUrl = URL.createObjectURL(blob);
+                s.onload = () => URL.revokeObjectURL(blobUrl);
+                s.onerror = () => {
+                    try { URL.revokeObjectURL(blobUrl); } catch (e) { }
+                    try { s.remove(); } catch (e) { }
+
+                    const fallback = targetDoc.createElement('script');
+                    if (id) fallback.id = id;
+                    if (attrs) Object.keys(attrs).forEach(k => fallback.setAttribute(k, attrs[k]));
+                    try { fallback.setAttribute('src', safeGetURL(scriptPath)); } catch (e) { fallback.src = safeGetURL(scriptPath) }
+                    targetDoc.head.appendChild(fallback);
+                };
                 try { s.setAttribute('src', blobUrl); } catch (e) { s.src = blobUrl }
                 targetDoc.head.appendChild(s);
             } catch (e) {

--- a/init.js
+++ b/init.js
@@ -9,27 +9,7 @@ try {
 } catch (e) { }
 
 var isPageWorld = !(typeof chrome !== 'undefined' && chrome.runtime);
-var cnpNativeFunctionStrings = window.cnpNativeFunctionStrings || new WeakMap();
-window.cnpNativeFunctionStrings = cnpNativeFunctionStrings;
-var cnpOriginalFunctionToString = window.cnpOriginalFunctionToString || Function.prototype.toString;
-window.cnpOriginalFunctionToString = cnpOriginalFunctionToString;
-
-if (!Function.prototype.cnpMirrorsNativeFunctions) {
-    const mirroredFunctionToString = {
-        toString() {
-            if (cnpNativeFunctionStrings.has(this))
-                return cnpNativeFunctionStrings.get(this);
-
-            return cnpOriginalFunctionToString.call(this);
-        }
-    }.toString;
-    cnpNativeFunctionStrings.set(mirroredFunctionToString, cnpOriginalFunctionToString.call(cnpOriginalFunctionToString));
-    Function.prototype.toString = mirrorNativeFunction(mirroredFunctionToString, cnpOriginalFunctionToString);
-    Object.defineProperty(Function.prototype, 'cnpMirrorsNativeFunctions', {
-        value: true,
-        configurable: true
-    });
-}
+var cnpOriginalFunctionToString = Function.prototype.toString;
 
 function mirrorNativeFunction(wrapper, original) {
     try {
@@ -41,7 +21,10 @@ function mirrorNativeFunction(wrapper, original) {
             value: original.length,
             configurable: true
         });
-        cnpNativeFunctionStrings.set(wrapper, cnpOriginalFunctionToString.call(original));
+        Object.defineProperty(wrapper, 'toString', {
+            value: () => cnpOriginalFunctionToString.call(original),
+            configurable: true
+        });
     } catch (e) { }
     return wrapper;
 }
@@ -127,6 +110,96 @@ function isCnPElement(element) {
     return !!(element && element.closest && element.closest('.cnp-overlay, .cnp-overlay-content'));
 }
 
+function uploadSurfaceText(element) {
+    if (!element || !element.getAttribute)
+        return '';
+
+    return [
+        element.id,
+        element.getAttribute('class'),
+        element.getAttribute('aria-label'),
+        element.getAttribute('title'),
+        element.getAttribute('name'),
+        element.getAttribute('data-testid'),
+        element.getAttribute('data-test-id'),
+        element.getAttribute('role'),
+        (element.innerText || element.textContent || '').slice(0, 200)
+    ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
+}
+
+function ignoredUploadSurfaceText(element) {
+    if (!element || !element.getAttribute)
+        return '';
+
+    return [
+        element.getAttribute('aria-label'),
+        element.getAttribute('title'),
+        element.getAttribute('name'),
+        element.getAttribute('role'),
+        (element.innerText || element.textContent || '').slice(0, 200)
+    ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
+}
+
+function isIgnoredUploadSurface(element) {
+    return /\bmeta\s+ai\s+business\s+assistant\b|\bmeta\s+ai\b/i.test(ignoredUploadSurfaceText(element));
+}
+
+function stopHostPagePropagation(event) {
+    event.stopPropagation();
+}
+
+function eventStartedInCnPElement(event) {
+    const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
+    return path.some(node => isCnPElement(node));
+}
+
+function stopCnPOverlayHostEvent(event) {
+    if (!eventStartedInCnPElement(event))
+        return;
+
+    event.stopPropagation();
+    if (typeof event.stopImmediatePropagation === 'function')
+        event.stopImmediatePropagation();
+}
+
+function eventStartedInCnPUploadActivationElement(event) {
+    const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
+    return path.some(node => node && node.id && (node.id === 'cnp-overlay-file-input' || node.id === 'cnp-upload-btn'));
+}
+
+function stopCnPUploadActivationHostEvent(event) {
+    if (!eventStartedInCnPUploadActivationElement(event))
+        return;
+
+    event.stopPropagation();
+    if (typeof event.stopImmediatePropagation === 'function')
+        event.stopImmediatePropagation();
+}
+
+function containCnPOverlayEvents(overlay) {
+    if (!overlay || !overlay.matches || !overlay.matches('.cnp-overlay') || overlay.dataset.cnpHostEventContainment)
+        return;
+
+    overlay.dataset.cnpHostEventContainment = 'true';
+    ['click', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'touchstart', 'touchend'].forEach(type => {
+        overlay.addEventListener(type, stopCnPOverlayHostEvent);
+    });
+}
+
+function installCnPOverlayEventContainment() {
+    document.querySelectorAll('.cnp-overlay').forEach(containCnPOverlayEvents);
+    const observer = new MutationObserver(mutations => {
+        mutations.forEach(mutation => {
+            mutation.addedNodes.forEach(node => {
+                containCnPOverlayEvents(node);
+                if (node.querySelectorAll)
+                    node.querySelectorAll('.cnp-overlay').forEach(containCnPOverlayEvents);
+            });
+        });
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+}
+
 function dispatchFilesToDropTarget(target, files) {
     const dataTransfer = new DataTransfer();
     [...files].forEach(file => dataTransfer.items.add(file));
@@ -148,6 +221,10 @@ function filesToFileList(files) {
 
 var pendingPickerlessFiles = null;
 var pendingPickerlessFallback = null;
+var pickerlessNativeBypassUntil = 0;
+var suppressPickerlessFileActivationUntil = 0;
+var pickerlessProxyTargets = new WeakMap();
+var pickerlessPreparedInputs = new WeakMap();
 
 function clearPendingPickerlessFiles() {
     if (pendingPickerlessFallback)
@@ -157,14 +234,201 @@ function clearPendingPickerlessFiles() {
     pendingPickerlessFiles = null;
 }
 
+function markPickerlessHandoff() {
+    try {
+        document.documentElement.dataset.cnpPickerlessHandoff = String(Date.now());
+    } catch (e) { }
+}
+
 function fulfillPendingPickerlessInput(input) {
     if (!pendingPickerlessFiles || !input || input.type !== 'file')
         return false;
 
     const files = pendingPickerlessFiles;
+    const prepared = pickerlessPreparedInputs.has(input);
+    const disabled = input.disabled;
     clearPendingPickerlessFiles();
     input.files = filesToFileList(input.multiple ? files : files.slice(0, 1));
+    try {
+        input.disabled = true;
+    } catch (e) { }
     triggerChangeEvent(input);
+    setTimeout(() => {
+        if (prepared)
+            restorePreparedPickerlessInput(input);
+        else {
+            try {
+                input.disabled = disabled;
+            } catch (e) { }
+        }
+    }, 0);
+    return true;
+}
+
+function restoreOwnProperty(element, name, hadOwnProperty, value) {
+    try {
+        if (hadOwnProperty)
+            Object.defineProperty(element, name, { value, configurable: true, writable: true });
+        else
+            delete element[name];
+    } catch (e) { }
+}
+
+function restorePreparedPickerlessInput(input) {
+    const state = pickerlessPreparedInputs.get(input);
+    if (!state)
+        return;
+
+    pickerlessPreparedInputs.delete(input);
+    try {
+        input.disabled = state.disabled;
+    } catch (e) { }
+    restoreOwnProperty(input, 'click', state.hadOwnClick, state.click);
+    restoreOwnProperty(input, 'showPicker', state.hadOwnShowPicker, state.showPicker);
+}
+
+function preparePendingPickerlessInput(input) {
+    if (!pendingPickerlessFiles || !isCnPFileInput(input) || pickerlessPreparedInputs.has(input))
+        return false;
+
+    const state = {
+        disabled: input.disabled,
+        hadOwnClick: Object.prototype.hasOwnProperty.call(input, 'click'),
+        click: input.click,
+        hadOwnShowPicker: Object.prototype.hasOwnProperty.call(input, 'showPicker'),
+        showPicker: input.showPicker
+    };
+    pickerlessPreparedInputs.set(input, state);
+
+    try {
+        input.disabled = true;
+    } catch (e) { }
+    try {
+        Object.defineProperty(input, 'click', {
+            value: function (...args) {
+                if (fulfillPendingPickerlessInput(input))
+                    return;
+
+                return typeof state.click === 'function' ? state.click.apply(this, args) : undefined;
+            },
+            configurable: true,
+            writable: true
+        });
+    } catch (e) { }
+    try {
+        Object.defineProperty(input, 'showPicker', {
+            value: function (...args) {
+                if (fulfillPendingPickerlessInput(input))
+                    return;
+
+                return typeof state.showPicker === 'function' ? state.showPicker.apply(this, args) : undefined;
+            },
+            configurable: true,
+            writable: true
+        });
+    } catch (e) { }
+    return true;
+}
+
+function fulfillPendingPickerlessInputsFrom(root) {
+    if (!pendingPickerlessFiles || !root)
+        return false;
+
+    if (isCnPFileInput(root))
+        return fulfillPendingPickerlessInput(root);
+
+    if (!root.querySelectorAll)
+        return false;
+
+    const input = [...root.querySelectorAll('input[type="file"]')].find(candidate => isCnPFileInput(candidate));
+    return !!(input && fulfillPendingPickerlessInput(input));
+}
+
+function installPendingPickerlessInputObserver() {
+    if (document.cnpPendingPickerlessInputObserver)
+        return;
+
+    document.cnpPendingPickerlessInputObserver = true;
+    const observer = new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+            if (!pendingPickerlessFiles)
+                return;
+
+            if (mutation.type === 'attributes' && fulfillPendingPickerlessInputsFrom(mutation.target))
+                return;
+
+            for (const node of mutation.addedNodes) {
+                if (fulfillPendingPickerlessInputsFrom(node))
+                    return;
+            }
+        }
+    });
+    observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['type']
+    });
+}
+
+function installPendingPickerlessCreationHooks() {
+    if (document.cnpPendingPickerlessCreationHooks)
+        return;
+
+    document.cnpPendingPickerlessCreationHooks = true;
+    const typeDescriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'type');
+    if (typeDescriptor && typeDescriptor.configurable && typeDescriptor.get && typeDescriptor.set) {
+        try {
+            Object.defineProperty(HTMLInputElement.prototype, 'type', {
+                configurable: true,
+                enumerable: typeDescriptor.enumerable,
+                get() {
+                    return typeDescriptor.get.call(this);
+                },
+                set(value) {
+                    typeDescriptor.set.call(this, value);
+                    if (String(value).toLowerCase() === 'file')
+                        preparePendingPickerlessInput(this);
+                }
+            });
+        } catch (e) { }
+    }
+
+    const originalSetAttribute = Element.prototype.setAttribute;
+    Element.prototype.setAttribute = mirrorNativeFunction(function setAttribute(...args) {
+        const result = originalSetAttribute.apply(this, args);
+        if (this instanceof HTMLInputElement && String(args[0]).toLowerCase() === 'type' && String(args[1]).toLowerCase() === 'file')
+            preparePendingPickerlessInput(this);
+        return result;
+    }, originalSetAttribute);
+}
+
+function markSuppressNextFileActivation(input) {
+    suppressPickerlessFileActivationUntil = Date.now() + 1500;
+    try {
+        document.documentElement.dataset.cnpSuppressFileActivation = String(Date.now());
+    } catch (e) { }
+    if (input && input.dataset)
+        input.dataset.cnpSuppressNextFileActivation = String(Date.now());
+}
+
+function shouldSuppressPickerlessFileActivation(input) {
+    if (Date.now() < suppressPickerlessFileActivationUntil)
+        return true;
+
+    return !!(input && input.dataset && Date.now() - Number(input.dataset.cnpSuppressNextFileActivation || 0) < 1500);
+}
+
+function stopNativePickerBypassEvent(event) {
+    event.stopPropagation();
+}
+
+function shouldBypassCnPForNativePicker(input) {
+    if (!input || input.type !== 'file' || Date.now() > pickerlessNativeBypassUntil)
+        return false;
+
+    input.dataset.cnpNativePickerBypass = String(Date.now());
+    input.addEventListener('click', stopNativePickerBypassEvent, { once: true });
     return true;
 }
 
@@ -173,6 +437,7 @@ function replayPickerlessUpload(control, dropTarget, files) {
         return false;
 
     pendingPickerlessFiles = files;
+    markPickerlessHandoff();
     pendingPickerlessFallback = setTimeout(() => {
         if (!pendingPickerlessFiles)
             return;
@@ -205,16 +470,109 @@ function findDropTarget(control) {
     return control.closest('[role="dialog"]') || document.body;
 }
 
-function isPickerlessUploadButton(element) {
-    if (!element || !element.matches || !visibleElement(element) || isCnPElement(element))
+function uploadControlText(element) {
+    return [
+        element.id,
+        element.getAttribute('class'),
+        element.getAttribute('aria-label'),
+        element.getAttribute('title'),
+        element.getAttribute('name'),
+        element.getAttribute('data-testid'),
+        element.getAttribute('data-test-id'),
+        element.innerText || element.textContent || ''
+    ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
+}
+
+function uploadControlUserText(element) {
+    return [
+        element.getAttribute('aria-label'),
+        element.getAttribute('title'),
+        element.getAttribute('name'),
+        element.getAttribute('data-testid'),
+        element.getAttribute('data-test-id'),
+        element.innerText || element.textContent || ''
+    ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
+}
+
+function uploadAcceptFromControl(control) {
+    const text = uploadControlText(control);
+    const acceptsImage = /\b(image|photo|picture)\b/i.test(text);
+    const acceptsVideo = /\b(video)\b/i.test(text);
+
+    if (acceptsImage && acceptsVideo)
+        return 'image/*,video/*';
+    if (acceptsImage)
+        return 'image/*';
+    if (acceptsVideo)
+        return 'video/*';
+
+    return /\b(photo|picture|image)\b/i.test(document.body.innerText || '') ? 'image/*' : '';
+}
+
+function uploadMultipleFromControl(control) {
+    return /\b(files|images|photos|pictures|videos|media)\b/i.test(uploadControlText(control));
+}
+
+function hasUploadIntent(text) {
+    return /\b(upload|attach|browse|choose|select)\b/i.test(text)
+        || (/\badd\b/i.test(text) && hasUploadObject(text));
+}
+
+function hasUploadObject(text) {
+    return /\b(file|files|image|images|photo|photos|picture|pictures|video|videos|media)\b/i.test(text);
+}
+
+function hasLocalUploadSource(text) {
+    return /\b(computer|desktop|device|local|disk|drive|folder|gallery|library)\b/i.test(text);
+}
+
+function hasNonUploadIntent(text) {
+    return /\b(display mode|saved posts?|save post|bookmark|reload|dismiss|close|camera|take a picture)\b/i.test(text);
+}
+
+function isMenuTrigger(element) {
+    if (!element || !element.getAttribute)
         return false;
-    if (!element.matches('button, a, label, [role="button"], .media-editor-file-selector__upload-media-button'))
+    if (element.matches && element.matches('[role="menuitem"], [role="menuitemradio"], [role="option"]'))
+        return false;
+
+    const hasPopup = element.getAttribute('aria-haspopup');
+    if (hasPopup && hasPopup !== 'false')
+        return true;
+
+    if (element.hasAttribute('aria-expanded'))
+        return true;
+
+    return /\b(dropdown|menu|caret|chevron)\b/i.test(uploadControlUserText(element));
+}
+
+function isLikelyPickerlessUploadText(text, negativeText = text) {
+    if (!hasUploadIntent(text) || hasNonUploadIntent(negativeText || text))
+        return false;
+
+    return hasUploadObject(text) || hasLocalUploadSource(text);
+}
+
+function shouldUseNativePickerlessUpload(control) {
+    return false;
+}
+
+function shouldAllowNativeUploadActivation(control) {
+    return false;
+}
+
+function isPickerlessUploadButton(element) {
+    if (!element || !element.matches || !visibleElement(element) || isCnPElement(element) || isIgnoredUploadSurface(element))
+        return false;
+    if (!element.matches('button, a, label, input[type="button"], input[type="submit"], [role="button"], [role="menuitem"], [role="menuitemradio"], [role="option"], .media-editor-file-selector__upload-media-button'))
         return false;
     if (element.matches('[role="dialog"], [role="tab"], [data-test-modal]'))
         return false;
+    if (isMenuTrigger(element))
+        return false;
 
-    const text = `${element.getAttribute('aria-label') || ''} ${element.innerText || element.textContent || ''}`.trim();
-    return /\b(upload from computer|choose file|select file|browse files?)\b/i.test(text);
+    const text = uploadControlText(element);
+    return isLikelyPickerlessUploadText(text, uploadControlUserText(element));
 }
 
 function findPickerlessUploadControl(event) {
@@ -233,17 +591,39 @@ function openOverlayForDropUpload(control) {
     const dropTarget = findDropTarget(control);
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = /\b(photo|picture|image)\b/i.test(document.body.innerText || '') ? 'image/*' : '';
+    input.accept = uploadAcceptFromControl(control);
+    input.multiple = uploadMultipleFromControl(control);
     input.dataset.cnpPickerProxy = 'true';
+    input.dataset.cnpPickerProxyNative = shouldUseNativePickerlessUpload(control) ? 'true' : 'false';
     input.style.display = 'none';
+    pickerlessProxyTargets.set(input, { control, dropTarget });
 
     input.addEventListener('change', () => {
         const files = [...input.files];
+        pickerlessProxyTargets.delete(input);
         input.remove();
         if (files.length > 0)
             replayPickerlessUpload(control, dropTarget, files);
     }, { once: true });
-    input.addEventListener('cnp-overlay-cancelled', () => input.remove(), { once: true });
+    input.addEventListener('cnp-overlay-cancelled', () => {
+        pickerlessProxyTargets.delete(input);
+        input.remove();
+    }, { once: true });
+
+    input.addEventListener('cnp-picker-proxy-native-upload', event => {
+        const target = pickerlessProxyTargets.get(input);
+        if (!target || input.dataset.cnpPickerProxyNative !== 'true')
+            return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === 'function')
+            event.stopImmediatePropagation();
+
+        input.dataset.cnpNativeUploadStarted = String(Date.now());
+        pickerlessNativeBypassUntil = Date.now() + 1500;
+        target.control.click();
+    });
 
     (document.body || document.documentElement).appendChild(input);
     if (!requestIsolatedOverlayForFileInput(input)) {
@@ -292,11 +672,35 @@ function openOverlayForFilePicker(options, fallback) {
 }
 
 function preventNativeFileActivation(event) {
-    if (!isPageWorld || !event.isTrusted)
+    if (!isPageWorld)
         return;
 
     const fileInput = findActivatedFileInput(event);
-    if (!fileInput || !requestIsolatedOverlayForFileInput(fileInput))
+    if (!fileInput)
+        return;
+    if (isIgnoredUploadSurface(fileInput))
+        return;
+
+    if (!event.isTrusted && shouldSuppressPickerlessFileActivation(fileInput)) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === 'function')
+            event.stopImmediatePropagation();
+        return;
+    }
+
+    if (pendingPickerlessFiles && fulfillPendingPickerlessInput(fileInput)) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === 'function')
+            event.stopImmediatePropagation();
+        return;
+    }
+
+    if (!event.isTrusted && navigator.userActivation && !navigator.userActivation.isActive)
+        return;
+
+    if (!requestIsolatedOverlayForFileInput(fileInput))
         return;
 
     event.preventDefault();
@@ -310,6 +714,9 @@ function preventPickerlessUploadActivation(event) {
         return;
 
     const control = findPickerlessUploadControl(event);
+    if (control && shouldAllowNativeUploadActivation(control))
+        return;
+
     if (!control || !openOverlayForDropUpload(control))
         return;
 
@@ -323,6 +730,14 @@ if (isPageWorld && !document.cnpPageFileActivationListener) {
     document.cnpPageFileActivationListener = true;
     document.addEventListener('click', preventNativeFileActivation, true);
     document.addEventListener('click', preventPickerlessUploadActivation, true);
+    document.addEventListener('cnp-overlay-created', event => containCnPOverlayEvents(event.target), true);
+    ['click', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'touchstart', 'touchend'].forEach(type => {
+        document.addEventListener(type, stopCnPOverlayHostEvent);
+        window.addEventListener(type, stopCnPUploadActivationHostEvent, true);
+    });
+    installPendingPickerlessCreationHooks();
+    installPendingPickerlessInputObserver();
+    installCnPOverlayEventContainment();
 }
 
 if (isPageWorld && typeof window.showOpenFilePicker === 'function' && !window.cnpShowOpenFilePicker) {
@@ -350,7 +765,13 @@ HTMLElement.prototype.click = mirrorNativeFunction({
     click(...args) {
         if (isCnPFileInput(this)) {
             if (isPageWorld) {
+                if (shouldBypassCnPForNativePicker(this))
+                    return oriClick.apply(this, args);
+
                 if (fulfillPendingPickerlessInput(this))
+                    return;
+
+                if (shouldSuppressPickerlessFileActivation(this))
                     return;
 
                 if (requestIsolatedOverlayForFileInput(this))
@@ -371,7 +792,17 @@ HTMLInputElement.prototype.click = mirrorNativeFunction({
     click(...args) {
         if (isCnPFileInput(this)) {
             if (isPageWorld) {
+                if (shouldBypassCnPForNativePicker(this)) {
+                    if (typeof oriInputClick === 'function')
+                        return oriInputClick.apply(this, args);
+
+                    return oriClick.apply(this, args);
+                }
+
                 if (fulfillPendingPickerlessInput(this))
+                    return;
+
+                if (shouldSuppressPickerlessFileActivation(this))
                     return;
 
                 if (requestIsolatedOverlayForFileInput(this))
@@ -398,7 +829,17 @@ HTMLInputElement.prototype.showPicker = mirrorNativeFunction({
     showPicker(...args) {
         if (isCnPFileInput(this)) {
             if (isPageWorld) {
+                if (shouldBypassCnPForNativePicker(this)) {
+                    if (typeof oriShowPicker === 'function')
+                        return oriShowPicker.apply(this, args);
+
+                    return oriClick.apply(this, args);
+                }
+
                 if (fulfillPendingPickerlessInput(this))
+                    return;
+
+                if (shouldSuppressPickerlessFileActivation(this))
                     return;
 
                 if (requestIsolatedOverlayForFileInput(this))
@@ -487,10 +928,14 @@ if (!document.cnpCoordListener)
 
 // Sets a node up for CnP Overlay
 function setupcreateOverlay(node) {
-    if (node.id != "cnp-overlay-file-input" && !node.dataset.cnpCreateListener) {
+    if (node.id != "cnp-overlay-file-input" && !node.dataset.cnpCreateListener && !isIgnoredUploadSurface(node)) {
         node.addEventListener("click", createOverlay);
         node.dataset.cnpCreateListener = "true";
     }
+}
+
+function shouldIgnoreUntrustedOverlayClick(event) {
+    return event.isTrusted === false;
 }
 
 // Ctrl V listener
@@ -720,12 +1165,26 @@ async function renderClipboardFiles(files, overlay, overlayFileInput) {
     }
 
     const imagePreviewContainer = overlay.querySelector('#cnp-preview-container');
-    imagePreviewContainer.style.cursor = 'pointer';
-    imagePreviewContainer.onclick = () => {
+    let previewAttached = false;
+    const attachPreviewFiles = event => {
+        if (previewAttached)
+            return;
+
+        previewAttached = true;
+        if (event) {
+            event.preventDefault();
+            event.stopPropagation();
+            if (typeof event.stopImmediatePropagation === 'function')
+                event.stopImmediatePropagation();
+        }
         originalInput.files = fileList.files;
         triggerChangeEvent(originalInput);
         closeOverlay();
     };
+
+    imagePreviewContainer.style.cursor = 'pointer';
+    imagePreviewContainer.addEventListener('pointerdown', attachPreviewFiles);
+    imagePreviewContainer.addEventListener('click', attachPreviewFiles);
     return true;
 }
 
@@ -852,11 +1311,23 @@ function ensureOverlayStyles() {
         }
 
         #cnp-overlay-file-input {
-            display: none;
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            opacity: 0;
+            cursor: default;
+            margin: 0;
+            padding: 0;
+            border: 0;
+            z-index: 1;
         }
 
         #cnp-upload {
+            position: relative;
+            z-index: 0;
             font-weight: normal;
+            pointer-events: none;
         }
 
         #cnp-upload svg {
@@ -865,8 +1336,11 @@ function ensureOverlayStyles() {
 
         .cnp-menu-item {
             cursor: default;
+            display: block;
             margin-bottom: 7px;
+            overflow: hidden;
             padding: 6px;
+            position: relative;
         }
 
         .cnp-menu-item:hover {
@@ -981,11 +1455,12 @@ function buildOverlayContent(overlay) {
     const overlayFileInput = document.createElement('input');
     overlayFileInput.type = 'file';
     overlayFileInput.id = 'cnp-overlay-file-input';
-    content.appendChild(overlayFileInput);
 
     const uploadBtn = document.createElement('div');
     uploadBtn.id = 'cnp-upload-btn';
     uploadBtn.className = 'cnp-menu-item';
+    uploadBtn.setAttribute('role', 'button');
+    uploadBtn.tabIndex = 0;
 
     const upload = document.createElement('span');
     upload.id = 'cnp-upload';
@@ -997,6 +1472,7 @@ function buildOverlayContent(overlay) {
     uploadText.textContent = 'Upload File';
     upload.appendChild(uploadText);
     uploadBtn.appendChild(upload);
+    uploadBtn.appendChild(overlayFileInput);
     content.appendChild(uploadBtn);
 
     overlay.appendChild(content);
@@ -1005,6 +1481,9 @@ function buildOverlayContent(overlay) {
 
 // When prepped input elements are clicked
 function createOverlay(event) {
+    if (shouldIgnoreUntrustedOverlayClick(event))
+        return;
+
     // Check if overlay is already visible for this input
     const existingOverlay = document.querySelector('.cnp-overlay');
 
@@ -1039,6 +1518,10 @@ function createOverlay(event) {
         buildOverlayContent(overlay);
 
                         document.body.appendChild(overlay);
+                        overlay.dispatchEvent(new CustomEvent('cnp-overlay-created', { bubbles: true, composed: true }));
+                        ['click', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'touchstart', 'touchend'].forEach(type => {
+                            overlay.addEventListener(type, stopHostPagePropagation);
+                        });
                         // Ensure overlay floats above page content even if page CSS wasn't copied
                         try {
                             overlay.style.left = overlay.style.left || '0px';
@@ -1090,8 +1573,24 @@ function createOverlay(event) {
 
                         // Overlay upload click listener
                         const uploadBtn = overlay.querySelector('#cnp-upload-btn');
-                        overlayFileInput.focus({ preventScroll: true });
-                        uploadBtn.onclick = () => overlayFileInput.click();
+                        uploadBtn.focus({ preventScroll: true });
+                        uploadBtn.onclick = event => {
+                            event.stopPropagation();
+                            if (originalInput.dataset && originalInput.dataset.cnpPickerProxyNative === 'true') {
+                                event.preventDefault();
+                                const nativeUploadEvent = new CustomEvent('cnp-picker-proxy-native-upload', {
+                                    bubbles: false,
+                                    cancelable: true,
+                                    composed: true
+                                });
+                                const nativeUploadAllowed = originalInput.dispatchEvent(nativeUploadEvent);
+                                const nativeUploadStarted = Date.now() - Number(originalInput.dataset.cnpNativeUploadStarted || 0) < 1500;
+                                if (!nativeUploadAllowed || nativeUploadEvent.defaultPrevented || nativeUploadStarted) {
+                                    closeOverlay();
+                                    return;
+                                }
+                            }
+                        };
 
                         // Close overlay when clicked outside
                         if (!document.cnpRemoveListener)
@@ -1218,6 +1717,8 @@ function cloneEvent(e) {
 
 // Trigger change event on original input to update value (like disabled buttons)
 function triggerChangeEvent(originalInput) {
+    if (!(originalInput.dataset && originalInput.dataset.cnpPickerProxy === 'true'))
+        markSuppressNextFileActivation(originalInput);
     originalInput.dispatchEvent(new Event('change', { bubbles: true }));
     originalInput.dispatchEvent(new Event('input', { bubbles: true }));
 }

--- a/init.js
+++ b/init.js
@@ -57,9 +57,10 @@ function findActivatedFileInput(event) {
 
 function requestIsolatedOverlayForFileInput(input) {
     try {
-        if (navigator.userActivation && !navigator.userActivation.isActive)
+        if (navigator.userActivation && !navigator.userActivation.isActive && !hasRecentFilePickerCandidate(input))
             return false;
 
+        input.dataset.cnpOverlayRequested = String(Date.now());
         input.dataset.cnpPageActivation = String(Date.now());
         input.dispatchEvent(new CustomEvent('cnp-page-file-input-activated', { bubbles: true, composed: true }));
         return true;
@@ -222,6 +223,7 @@ function filesToFileList(files) {
 var pendingPickerlessFiles = null;
 var pendingPickerlessFallback = null;
 var pickerlessNativeBypassUntil = 0;
+var trustedFilePickerGestureUntil = 0;
 var suppressPickerlessFileActivationUntil = 0;
 var pickerlessProxyTargets = new WeakMap();
 var pickerlessPreparedInputs = new WeakMap();
@@ -238,6 +240,34 @@ function markPickerlessHandoff() {
     try {
         document.documentElement.dataset.cnpPickerlessHandoff = String(Date.now());
     } catch (e) { }
+}
+
+function markTrustedFilePickerGesture(event) {
+    if (!event || !event.isTrusted || (event.target && isCnPElement(event.target)))
+        return;
+
+    trustedFilePickerGestureUntil = Date.now() + 1500;
+}
+
+function hasTrustedFilePickerGesture() {
+    return Date.now() < trustedFilePickerGestureUntil;
+}
+
+function hasRecentOverlayRequest(input) {
+    return !!(input && input.dataset && Date.now() - Number(input.dataset.cnpOverlayRequested || 0) < 1500);
+}
+
+function markFilePickerCandidate(input) {
+    if (!input || input.type !== 'file' || !hasTrustedFilePickerGesture())
+        return;
+
+    try {
+        input.dataset.cnpFilePickerCandidate = String(Date.now());
+    } catch (e) { }
+}
+
+function hasRecentFilePickerCandidate(input) {
+    return !!(input && input.dataset && Date.now() - Number(input.dataset.cnpFilePickerCandidate || 0) < 1500);
 }
 
 function fulfillPendingPickerlessInput(input) {
@@ -344,6 +374,21 @@ function fulfillPendingPickerlessInputsFrom(root) {
     return !!(input && fulfillPendingPickerlessInput(input));
 }
 
+function markFilePickerCandidatesFrom(root) {
+    if (!root)
+        return;
+
+    if (isCnPFileInput(root)) {
+        markFilePickerCandidate(root);
+        return;
+    }
+
+    if (!root.querySelectorAll)
+        return;
+
+    root.querySelectorAll('input[type="file"]').forEach(markFilePickerCandidate);
+}
+
 function installPendingPickerlessInputObserver() {
     if (document.cnpPendingPickerlessInputObserver)
         return;
@@ -351,8 +396,14 @@ function installPendingPickerlessInputObserver() {
     document.cnpPendingPickerlessInputObserver = true;
     const observer = new MutationObserver(mutations => {
         for (const mutation of mutations) {
+            if (mutation.type === 'attributes')
+                markFilePickerCandidatesFrom(mutation.target);
+
+            for (const node of mutation.addedNodes)
+                markFilePickerCandidatesFrom(node);
+
             if (!pendingPickerlessFiles)
-                return;
+                continue;
 
             if (mutation.type === 'attributes' && fulfillPendingPickerlessInputsFrom(mutation.target))
                 return;
@@ -387,8 +438,10 @@ function installPendingPickerlessCreationHooks() {
                 },
                 set(value) {
                     typeDescriptor.set.call(this, value);
-                    if (String(value).toLowerCase() === 'file')
+                    if (String(value).toLowerCase() === 'file') {
+                        markFilePickerCandidate(this);
                         preparePendingPickerlessInput(this);
+                    }
                 }
             });
         } catch (e) { }
@@ -397,8 +450,10 @@ function installPendingPickerlessCreationHooks() {
     const originalSetAttribute = Element.prototype.setAttribute;
     Element.prototype.setAttribute = mirrorNativeFunction(function setAttribute(...args) {
         const result = originalSetAttribute.apply(this, args);
-        if (this instanceof HTMLInputElement && String(args[0]).toLowerCase() === 'type' && String(args[1]).toLowerCase() === 'file')
+        if (this instanceof HTMLInputElement && String(args[0]).toLowerCase() === 'type' && String(args[1]).toLowerCase() === 'file') {
+            markFilePickerCandidate(this);
             preparePendingPickerlessInput(this);
+        }
         return result;
     }, originalSetAttribute);
 }
@@ -494,6 +549,24 @@ function uploadControlUserText(element) {
     ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
 }
 
+function uploadControlContextText(element) {
+    if (!element || !element.closest)
+        return '';
+
+    const context = element.closest('[role="dialog"], [aria-modal="true"], simplified-input-menu, [role="menu"], [role="listbox"]')
+        || element.parentElement;
+    return (context && (context.innerText || context.textContent || '') || '').slice(0, 400).replace(/[-_]+/g, ' ');
+}
+
+function hasNearbyFileInput(element) {
+    let current = element;
+    for (let depth = 0; current && depth < 5; depth += 1, current = current.parentElement) {
+        if (current.querySelector && current.querySelector('input[type="file"]'))
+            return true;
+    }
+    return false;
+}
+
 function uploadAcceptFromControl(control) {
     const text = uploadControlText(control);
     const acceptsImage = /\b(image|photo|picture)\b/i.test(text);
@@ -526,8 +599,72 @@ function hasLocalUploadSource(text) {
     return /\b(computer|desktop|device|local|disk|drive|folder|gallery|library)\b/i.test(text);
 }
 
+function hasRemoteUploadSource(text) {
+    return /\bcloud\b|\bone\s*drive\b|\bgoogle\s+drive\b|\bicloud\b|\bsharepoint\b|\bdropbox\b/i.test(text);
+}
+
+function hasRemoteFileProvider(text) {
+    return /\bone\s*drive\b|\bgoogle\s+drive\b|\bicloud\b|\bsharepoint\b|\bdropbox\b/i.test(text);
+}
+
+function remoteFilePickerSurfaceText(element) {
+    if (!element || !element.getAttribute)
+        return '';
+
+    return [
+        element.id,
+        element.getAttribute('class'),
+        element.getAttribute('aria-label'),
+        element.getAttribute('title'),
+        element.getAttribute('name'),
+        element.getAttribute('data-testid'),
+        element.getAttribute('data-test-id'),
+        element.getAttribute('data-automationid'),
+        element.getAttribute('data-automation-id'),
+        element.getAttribute('role'),
+        (element.innerText || element.textContent || '').slice(0, 800)
+    ].filter(Boolean).join(' ').replace(/[-_]+/g, ' ');
+}
+
+function isInsideRemoteFilePicker(element) {
+    if (!element || !element.parentElement)
+        return false;
+
+    const pageText = [location.hostname, location.pathname, document.title].join(' ');
+    if (hasRemoteFileProvider(pageText))
+        return true;
+
+    let current = element.parentElement;
+    for (let depth = 0; current && current !== document.documentElement && depth < 10; depth += 1, current = current.parentElement) {
+        const text = remoteFilePickerSurfaceText(current);
+        if (hasRemoteFileProvider(text) && /\b(my\s+files|files?|folders?|recent|shared|upload|cloud)\b/i.test(text))
+            return true;
+        if (/\bcloud\s+files\b/i.test(text) && /\bmy\s+files\b/i.test(text))
+            return true;
+    }
+
+    return false;
+}
+
+function hasExplicitFileSelectionIntent(text) {
+    return /\b(attach|browse|choose|select)\b/i.test(text)
+        || (/\badd\b/i.test(text) && hasUploadObject(text));
+}
+
+function hasNearbyFileSelectionIntent(text, element) {
+    return !!(element && hasNearbyFileInput(element) && /\b(add|change|edit|replace)\b/i.test(text) && hasUploadObject(text));
+}
+
 function hasNonUploadIntent(text) {
     return /\b(display mode|saved posts?|save post|bookmark|reload|dismiss|close|camera|take a picture)\b/i.test(text);
+}
+
+function isUploadMenuChoice(element) {
+    if (!element || !element.matches)
+        return false;
+
+    return element.matches('[role="menuitem"], [role="menuitemradio"], [role="option"], .media-editor-file-selector__upload-media-button')
+        || !!element.closest('simplified-input-menu, [role="menu"], [role="listbox"]');
 }
 
 function isMenuTrigger(element) {
@@ -543,14 +680,34 @@ function isMenuTrigger(element) {
     if (element.hasAttribute('aria-expanded'))
         return true;
 
-    return /\b(dropdown|menu|caret|chevron)\b/i.test(uploadControlUserText(element));
+    const controlledId = element.getAttribute('aria-controls') || element.getAttribute('aria-owns');
+    if (controlledId) {
+        const controlled = document.getElementById(controlledId);
+        if (controlled && controlled.matches && controlled.matches('[role="menu"], [role="listbox"], .ui-menu'))
+            return true;
+    }
+
+    return /\b(dropdown|drop\s*down|menu|menu\s*button|menubutton|split\s*button|splitbutton|caret|chevron|flyout|popover)\b/i.test(uploadControlText(element));
 }
 
-function isLikelyPickerlessUploadText(text, negativeText = text) {
-    if (!hasUploadIntent(text) || hasNonUploadIntent(negativeText || text))
+function isLikelyPickerlessUploadText(text, negativeText = text, element = null) {
+    const contextText = element ? uploadControlContextText(element) : '';
+    const hasIntent = hasUploadIntent(text)
+        || hasNearbyFileSelectionIntent(text, element);
+
+    if (!hasIntent || hasNonUploadIntent(negativeText || text) || hasRemoteUploadSource(negativeText || text))
         return false;
 
-    return hasUploadObject(text) || hasLocalUploadSource(text);
+    if (hasLocalUploadSource(text))
+        return true;
+
+    if (hasExplicitFileSelectionIntent(text))
+        return true;
+
+    if (/\bupload\b/i.test(text) && hasUploadObject(contextText))
+        return true;
+
+    return hasUploadObject(text) && isUploadMenuChoice(element);
 }
 
 function shouldUseNativePickerlessUpload(control) {
@@ -564,15 +721,35 @@ function shouldAllowNativeUploadActivation(control) {
 function isPickerlessUploadButton(element) {
     if (!element || !element.matches || !visibleElement(element) || isCnPElement(element) || isIgnoredUploadSurface(element))
         return false;
-    if (!element.matches('button, a, label, input[type="button"], input[type="submit"], [role="button"], [role="menuitem"], [role="menuitemradio"], [role="option"], .media-editor-file-selector__upload-media-button'))
+    if (!element.matches('button, label, input[type="button"], input[type="submit"], [role="button"], [role="menuitem"], [role="menuitemradio"], [role="option"], .media-editor-file-selector__upload-media-button')
+        && !(element.matches('a') && isUploadMenuChoice(element)))
         return false;
     if (element.matches('[role="dialog"], [role="tab"], [data-test-modal]'))
         return false;
     if (isMenuTrigger(element))
         return false;
+    if (isInsideRemoteFilePicker(element))
+        return false;
 
     const text = uploadControlText(element);
-    return isLikelyPickerlessUploadText(text, uploadControlUserText(element));
+    return isLikelyPickerlessUploadText(text, uploadControlUserText(element), element);
+}
+
+function preventPickerlessUploadActivation(event) {
+    if (!isPageWorld || !event.isTrusted)
+        return;
+
+    const control = findPickerlessUploadControl(event);
+    if (control && shouldAllowNativeUploadActivation(control))
+        return;
+
+    if (!control || !openOverlayForDropUpload(control))
+        return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (typeof event.stopImmediatePropagation === 'function')
+        event.stopImmediatePropagation();
 }
 
 function findPickerlessUploadControl(event) {
@@ -697,7 +874,7 @@ function preventNativeFileActivation(event) {
         return;
     }
 
-    if (!event.isTrusted && navigator.userActivation && !navigator.userActivation.isActive)
+    if (!event.isTrusted && navigator.userActivation && !navigator.userActivation.isActive && !hasRecentFilePickerCandidate(fileInput))
         return;
 
     if (!requestIsolatedOverlayForFileInput(fileInput))
@@ -709,25 +886,9 @@ function preventNativeFileActivation(event) {
         event.stopImmediatePropagation();
 }
 
-function preventPickerlessUploadActivation(event) {
-    if (!isPageWorld || !event.isTrusted)
-        return;
-
-    const control = findPickerlessUploadControl(event);
-    if (control && shouldAllowNativeUploadActivation(control))
-        return;
-
-    if (!control || !openOverlayForDropUpload(control))
-        return;
-
-    event.preventDefault();
-    event.stopPropagation();
-    if (typeof event.stopImmediatePropagation === 'function')
-        event.stopImmediatePropagation();
-}
-
 if (isPageWorld && !document.cnpPageFileActivationListener) {
     document.cnpPageFileActivationListener = true;
+    ['pointerdown', 'mousedown', 'click', 'keydown'].forEach(type => document.addEventListener(type, markTrustedFilePickerGesture, true));
     document.addEventListener('click', preventNativeFileActivation, true);
     document.addEventListener('click', preventPickerlessUploadActivation, true);
     document.addEventListener('cnp-overlay-created', event => containCnPOverlayEvents(event.target), true);
@@ -1493,15 +1654,20 @@ function createOverlay(event) {
     // Check if overlay is already visible for this input
     const existingOverlay = document.querySelector('.cnp-overlay');
 
-    // If overlay exists, this is a second click - bypass extension and allow native behavior
+    // If an overlay already exists, recreate it for the new activation.  Keep the
+    // recent-request guard so duplicate site-triggered activations for the same
+    // input do not immediately close/reopen the overlay.
     if (existingOverlay) {
-        // Remove the overlay
+        if (event.target && hasRecentOverlayRequest(event.target)) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+
         closeOverlay();
-        // Don't prevent default - let the native file picker open
-        return;
     }
 
-    // First click - prevent default and show overlay
+    // Prevent default and show overlay
     event.preventDefault();
     event.stopPropagation();
     originalInput = event.target;
@@ -1523,197 +1689,197 @@ function createOverlay(event) {
 
         buildOverlayContent(overlay);
 
-                        document.body.appendChild(overlay);
-                        overlay.dispatchEvent(new CustomEvent('cnp-overlay-created', { bubbles: true, composed: true }));
-                        ['click', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'touchstart', 'touchend'].forEach(type => {
-                            overlay.addEventListener(type, stopHostPagePropagation);
-                        });
-                        // Ensure overlay floats above page content even if page CSS wasn't copied
-                        try {
-                            overlay.style.left = overlay.style.left || '0px';
-                            overlay.style.top = overlay.style.top || '0px';
-                            overlay.style.zIndex = overlay.style.zIndex || '2147483647';
-                        } catch (e) { logging(e) }
+        document.body.appendChild(overlay);
+        overlay.dispatchEvent(new CustomEvent('cnp-overlay-created', { bubbles: true, composed: true }));
+        ['click', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'touchstart', 'touchend'].forEach(type => {
+            overlay.addEventListener(type, stopHostPagePropagation);
+        });
+        // Ensure overlay floats above page content even if page CSS wasn't copied
+        try {
+            overlay.style.left = overlay.style.left || '0px';
+            overlay.style.top = overlay.style.top || '0px';
+            overlay.style.zIndex = overlay.style.zIndex || '2147483647';
+        } catch (e) { logging(e) }
 
-                        // Position overlay to cursor coord
-                        const overlayContent = overlay.querySelector('.cnp-overlay-content');
-                        if (!overlayContent) {
-                            logging('overlay content missing after insertion');
-                            return;
-                        }
+        // Position overlay to cursor coord
+        const overlayContent = overlay.querySelector('.cnp-overlay-content');
+        if (!overlayContent) {
+            logging('overlay content missing after insertion');
+            return;
+        }
 
-                        let overlayLeftPos = clientX + window.scrollX + (overlayContent.offsetWidth / 2);
-                        let overlayBottomPos = clientY + window.scrollY + (overlayContent.offsetHeight / 2);
+        let overlayLeftPos = clientX + window.scrollX + (overlayContent.offsetWidth / 2);
+        let overlayBottomPos = clientY + window.scrollY + (overlayContent.offsetHeight / 2);
 
-                        // Flip if overlay overshoots
-                        const tooMuchRight = overlayLeftPos + (overlayContent.offsetWidth / 2);
-                        const tooMuchBottom = overlayBottomPos + (overlayContent.offsetHeight / 2);
+        // Flip if overlay overshoots
+        const tooMuchRight = overlayLeftPos + (overlayContent.offsetWidth / 2);
+        const tooMuchBottom = overlayBottomPos + (overlayContent.offsetHeight / 2);
 
-                        if (tooMuchRight >= innerWidth)
-                            overlayLeftPos -= overlayContent.offsetWidth;
-                        if (tooMuchBottom >= innerHeight)
-                            overlayBottomPos -= overlayContent.offsetHeight;
+        if (tooMuchRight >= innerWidth)
+            overlayLeftPos -= overlayContent.offsetWidth;
+        if (tooMuchBottom >= innerHeight)
+            overlayBottomPos -= overlayContent.offsetHeight;
 
-                        overlayContent.style.left = overlayLeftPos + 'px';
-                        overlayContent.style.top = overlayBottomPos + 'px';
+        overlayContent.style.left = overlayLeftPos + 'px';
+        overlayContent.style.top = overlayBottomPos + 'px';
 
-                        // Follow attributes of original input element
-                        const overlayFileInput = overlay.querySelector('#cnp-overlay-file-input');
-                        overlayFileInput.multiple = originalInput.multiple;
-                        overlayFileInput.webkitdirectory = originalInput.webkitdirectory;
+        // Follow attributes of original input element
+        const overlayFileInput = overlay.querySelector('#cnp-overlay-file-input');
+        overlayFileInput.multiple = originalInput.multiple;
+        overlayFileInput.webkitdirectory = originalInput.webkitdirectory;
 
-                        if (overlayFileInput.multiple)
-                            overlay.querySelector('#cnp-upload-text').textContent = "Upload Files";
+        if (overlayFileInput.multiple)
+            overlay.querySelector('#cnp-upload-text').textContent = "Upload Files";
 
-                        // Overlay handle file input
-                        overlayFileInput.setAttribute('accept', originalInput.getAttribute('accept'));
-                        overlayFileInput.oncancel = () => closeOverlay();
-                        overlayFileInput.onchange = event => {
-                            const fileList = new DataTransfer();
-                            if (shouldAppendExistingFiles(originalInput))
-                                [...originalInput.files].forEach(file => fileList.items.add(file));
-                            [...event.target.files].forEach(file => fileList.items.add(file));
-                            originalInput.files = fileList.files;
-                            triggerChangeEvent(originalInput);
-                            closeOverlay();
-                        }
+        // Overlay handle file input
+        overlayFileInput.setAttribute('accept', originalInput.getAttribute('accept'));
+        overlayFileInput.oncancel = () => closeOverlay();
+        overlayFileInput.onchange = event => {
+            const fileList = new DataTransfer();
+            if (shouldAppendExistingFiles(originalInput))
+                [...originalInput.files].forEach(file => fileList.items.add(file));
+            [...event.target.files].forEach(file => fileList.items.add(file));
+            originalInput.files = fileList.files;
+            triggerChangeEvent(originalInput);
+            closeOverlay();
+        }
 
-                        // Overlay upload click listener
-                        const uploadBtn = overlay.querySelector('#cnp-upload-btn');
-                        uploadBtn.focus({ preventScroll: true });
-                        uploadBtn.onclick = event => {
-                            event.stopPropagation();
-                            if (originalInput.dataset && originalInput.dataset.cnpPickerProxyNative === 'true') {
-                                event.preventDefault();
-                                const nativeUploadEvent = new CustomEvent('cnp-picker-proxy-native-upload', {
-                                    bubbles: false,
-                                    cancelable: true,
-                                    composed: true
-                                });
-                                const nativeUploadAllowed = originalInput.dispatchEvent(nativeUploadEvent);
-                                const nativeUploadStarted = Date.now() - Number(originalInput.dataset.cnpNativeUploadStarted || 0) < 1500;
-                                if (!nativeUploadAllowed || nativeUploadEvent.defaultPrevented || nativeUploadStarted) {
-                                    closeOverlay();
-                                    return;
-                                }
-                            }
-                        };
+        // Overlay upload click listener
+        const uploadBtn = overlay.querySelector('#cnp-upload-btn');
+        uploadBtn.focus({ preventScroll: true });
+        uploadBtn.onclick = event => {
+            event.stopPropagation();
+            if (originalInput.dataset && originalInput.dataset.cnpPickerProxyNative === 'true') {
+                event.preventDefault();
+                const nativeUploadEvent = new CustomEvent('cnp-picker-proxy-native-upload', {
+                    bubbles: false,
+                    cancelable: true,
+                    composed: true
+                });
+                const nativeUploadAllowed = originalInput.dispatchEvent(nativeUploadEvent);
+                const nativeUploadStarted = Date.now() - Number(originalInput.dataset.cnpNativeUploadStarted || 0) < 1500;
+                if (!nativeUploadAllowed || nativeUploadEvent.defaultPrevented || nativeUploadStarted) {
+                    closeOverlay();
+                    return;
+                }
+            }
+        };
 
-                        // Close overlay when clicked outside
-                        if (!document.cnpRemoveListener)
-                            document.addEventListener('click', event => {
-                                document.cnpRemoveListener = true;
-                                document.querySelectorAll('.cnp-overlay-content').forEach(overlayContent => {
-                                    const overlay = overlayContent.closest('.cnp-overlay');
-                                    if (overlay && Date.now() < Number(overlay.dataset.cnpIgnoreCloseUntil || 0))
-                                        return;
+        // Close overlay when clicked outside
+        if (!document.cnpRemoveListener)
+            document.addEventListener('click', event => {
+                document.cnpRemoveListener = true;
+                document.querySelectorAll('.cnp-overlay-content').forEach(overlayContent => {
+                    const overlay = overlayContent.closest('.cnp-overlay');
+                    if (overlay && Date.now() < Number(overlay.dataset.cnpIgnoreCloseUntil || 0))
+                        return;
 
-                                    if (!overlayContent.contains(event.target))
-                                        closeOverlay();
-                                })
-                            })
+                    if (!overlayContent.contains(event.target))
+                        closeOverlay();
+                })
+            })
 
-                        // Handle dragover event
-                        const CNP_dropText = overlay.querySelector('#cnp-drop-text');
-                        overlay.ondragover = event => {
-                            event.stopPropagation();
-                            event.preventDefault();
-                            CNP_dropText.style.display = 'flex';
-                        };
+        // Handle dragover event
+        const CNP_dropText = overlay.querySelector('#cnp-drop-text');
+        overlay.ondragover = event => {
+            event.stopPropagation();
+            event.preventDefault();
+            CNP_dropText.style.display = 'flex';
+        };
 
-                        // Handle dragleave event
-                        overlay.ondragleave = event => {
-                            if (!overlay.contains(event.relatedTarget))
-                                CNP_dropText.style.display = 'none';
-                        };
+        // Handle dragleave event
+        overlay.ondragleave = event => {
+            if (!overlay.contains(event.relatedTarget))
+                CNP_dropText.style.display = 'none';
+        };
 
-                        // Handle drop event
-                        overlay.ondrop = event => {
-                            event.preventDefault();
-                            CNP_dropText.style.display = 'none';
-                            const fileList = new DataTransfer();
-                            // Preserve existing files only for multi-file inputs.
-                            const excludedFolders = [...event.dataTransfer.files].filter(file => !(file.size === 0 && file.type === ''));
-                            if (shouldAppendExistingFiles(originalInput))
-                                [...originalInput.files].forEach(file => fileList.items.add(file));
-                            [...excludedFolders].forEach(file => fileList.items.add(file));
-                            originalInput.files = fileList.files;
-                            triggerChangeEvent(originalInput);
-                            closeOverlay();
-                        };
+        // Handle drop event
+        overlay.ondrop = event => {
+            event.preventDefault();
+            CNP_dropText.style.display = 'none';
+            const fileList = new DataTransfer();
+            // Preserve existing files only for multi-file inputs.
+            const excludedFolders = [...event.dataTransfer.files].filter(file => !(file.size === 0 && file.type === ''));
+            if (shouldAppendExistingFiles(originalInput))
+                [...originalInput.files].forEach(file => fileList.items.add(file));
+            [...excludedFolders].forEach(file => fileList.items.add(file));
+            originalInput.files = fileList.files;
+            triggerChangeEvent(originalInput);
+            closeOverlay();
+        };
 
-                        // Handle Ctrl+V action
-                        document.addEventListener('keydown', ctrlV);
+        // Handle Ctrl+V action
+        document.addEventListener('keydown', ctrlV);
 
-                        var isClipboardPreviewResolved = false;
-                        const finishClipboardPreview = () => isClipboardPreviewResolved = true;
-                        const fallbackNoImageTimer = setTimeout(() => {
-                            if (!isClipboardPreviewResolved && document.getElementById(overlay.id)) {
-                                finishClipboardPreview();
-                                noImage();
-                            }
-                        }, 800);
+        var isClipboardPreviewResolved = false;
+        const finishClipboardPreview = () => isClipboardPreviewResolved = true;
+        const fallbackNoImageTimer = setTimeout(() => {
+            if (!isClipboardPreviewResolved && document.getElementById(overlay.id)) {
+                finishClipboardPreview();
+                noImage();
+            }
+        }, 800);
 
-                        // Handle paste event — use a short-lived isolated textarea so clipboard
-                        // content never enters the overlay DOM and the listener is scoped to a
-                        // specific element rather than the entire document.  A closure-level guard
-                        // (pasteExpected) prevents any external execCommand call from satisfying
-                        // the listener because the guard is set and consumed in the same
-                        // synchronous frame and is inaccessible to page scripts.
-                        const pasteProxy = document.createElement('div');
-                        pasteProxy.setAttribute('aria-hidden', 'true');
-                        pasteProxy.contentEditable = 'true';
-                        pasteProxy.tabIndex = -1;
-                        pasteProxy.style.cssText = 'position:fixed;opacity:0;width:1px;height:1px;top:0;left:0;overflow:hidden;pointer-events:none;';
-                        (document.body || document.documentElement).appendChild(pasteProxy);
+        // Handle paste event — use a short-lived isolated textarea so clipboard
+        // content never enters the overlay DOM and the listener is scoped to a
+        // specific element rather than the entire document.  A closure-level guard
+        // (pasteExpected) prevents any external execCommand call from satisfying
+        // the listener because the guard is set and consumed in the same
+        // synchronous frame and is inaccessible to page scripts.
+        const pasteProxy = document.createElement('div');
+        pasteProxy.setAttribute('aria-hidden', 'true');
+        pasteProxy.contentEditable = 'true';
+        pasteProxy.tabIndex = -1;
+        pasteProxy.style.cssText = 'position:fixed;opacity:0;width:1px;height:1px;top:0;left:0;overflow:hidden;pointer-events:none;';
+        (document.body || document.documentElement).appendChild(pasteProxy);
 
-                        let pasteExpected = false;
-                        pasteProxy.addEventListener('paste', async event => {
-                            event.stopPropagation();
-                            event.preventDefault();
+        let pasteExpected = false;
+        pasteProxy.addEventListener('paste', async event => {
+            event.stopPropagation();
+            event.preventDefault();
 
-                            if (!pasteExpected)
-                                return;
-                            pasteExpected = false;
+            if (!pasteExpected)
+                return;
+            pasteExpected = false;
 
-                            // Clear and remove the proxy immediately so pasted text cannot be
-                            // read from the DOM by page scripts.
-                            if (pasteProxy.textContent)
-                                pasteProxy.textContent = '';
-                            pasteProxy.remove();
+            // Clear and remove the proxy immediately so pasted text cannot be
+            // read from the DOM by page scripts.
+            if (pasteProxy.textContent)
+                pasteProxy.textContent = '';
+            pasteProxy.remove();
 
-                            if (isClipboardPreviewResolved || !overlayFileInput)
-                                return;
+            if (isClipboardPreviewResolved || !overlayFileInput)
+                return;
 
-                            const dataTransfer = event.clipboardData;
-                            ctrlVdata = cloneEvent(event.clipboardData);
-                            finishClipboardPreview();
-                            clearTimeout(fallbackNoImageTimer);
-                            await renderClipboardFiles(dataTransfer.files, overlay, overlayFileInput);
-                        }, { once: true });
+            const dataTransfer = event.clipboardData;
+            ctrlVdata = cloneEvent(event.clipboardData);
+            finishClipboardPreview();
+            clearTimeout(fallbackNoImageTimer);
+            await renderClipboardFiles(dataTransfer.files, overlay, overlayFileInput);
+        }, { once: true });
 
-                        // Set the guard immediately before focus+execCommand — both are
-                        // synchronous so no external code can interleave between the two.
-                        pasteProxy.focus({ preventScroll: true });
-                        if (document.activeElement === pasteProxy) {
-                            pasteExpected = true;
-                            document.execCommand('paste');
-                            pasteExpected = false; // reset if execCommand did not dispatch synchronously
-                        }
+        // Set the guard immediately before focus+execCommand — both are
+        // synchronous so no external code can interleave between the two.
+        pasteProxy.focus({ preventScroll: true });
+        if (document.activeElement === pasteProxy) {
+            pasteExpected = true;
+            document.execCommand('paste');
+            pasteExpected = false; // reset if execCommand did not dispatch synchronously
+        }
 
-                        // Schedule cleanup in case execCommand did not fire the paste event
-                        if (pasteProxy.isConnected)
-                            setTimeout(() => { if (pasteProxy.textContent) pasteProxy.textContent = ''; pasteProxy.remove(); }, 1000);
+        // Schedule cleanup in case execCommand did not fire the paste event
+        if (pasteProxy.isConnected)
+            setTimeout(() => { if (pasteProxy.textContent) pasteProxy.textContent = ''; pasteProxy.remove(); }, 1000);
 
-                        setTimeout(async () => {
-                            const files = await readClipboardFiles().catch(() => []);
-                            if (isClipboardPreviewResolved || files.length == 0)
-                                return;
+        setTimeout(async () => {
+            const files = await readClipboardFiles().catch(() => []);
+            if (isClipboardPreviewResolved || files.length == 0)
+                return;
 
-                            finishClipboardPreview();
-                            clearTimeout(fallbackNoImageTimer);
-                            await renderClipboardFiles(files, overlay, overlayFileInput);
-                        }, 50);
+            finishClipboardPreview();
+            clearTimeout(fallbackNoImageTimer);
+            await renderClipboardFiles(files, overlay, overlayFileInput);
+        }, 50);
     } catch (error) { logging(error) }
 }
 

--- a/init.js
+++ b/init.js
@@ -1645,10 +1645,33 @@ function createOverlay(event) {
                             }
                         }, 800);
 
-                        // Handle paste event
-                        document.addEventListener('paste', async event => {
+                        // Handle paste event — use a short-lived isolated textarea so clipboard
+                        // content never enters the overlay DOM and the listener is scoped to a
+                        // specific element rather than the entire document.  A closure-level guard
+                        // (pasteExpected) prevents any external execCommand call from satisfying
+                        // the listener because the guard is set and consumed in the same
+                        // synchronous frame and is inaccessible to page scripts.
+                        const pasteProxy = document.createElement('div');
+                        pasteProxy.setAttribute('aria-hidden', 'true');
+                        pasteProxy.contentEditable = 'true';
+                        pasteProxy.tabIndex = -1;
+                        pasteProxy.style.cssText = 'position:fixed;opacity:0;width:1px;height:1px;top:0;left:0;overflow:hidden;pointer-events:none;';
+                        (document.body || document.documentElement).appendChild(pasteProxy);
+
+                        let pasteExpected = false;
+                        pasteProxy.addEventListener('paste', async event => {
                             event.stopPropagation();
                             event.preventDefault();
+
+                            if (!pasteExpected)
+                                return;
+                            pasteExpected = false;
+
+                            // Clear and remove the proxy immediately so pasted text cannot be
+                            // read from the DOM by page scripts.
+                            if (pasteProxy.textContent)
+                                pasteProxy.textContent = '';
+                            pasteProxy.remove();
 
                             if (isClipboardPreviewResolved || !overlayFileInput)
                                 return;
@@ -1658,13 +1681,20 @@ function createOverlay(event) {
                             finishClipboardPreview();
                             clearTimeout(fallbackNoImageTimer);
                             await renderClipboardFiles(dataTransfer.files, overlay, overlayFileInput);
-                        }, { once: true, capture: true });
+                        }, { once: true });
 
-                        // Trigger paste event
-                        overlay.contentEditable = true;
-                        overlay.focus({ preventScroll: true });
-                        document.execCommand('paste');
-                        overlay.contentEditable = false;
+                        // Set the guard immediately before focus+execCommand — both are
+                        // synchronous so no external code can interleave between the two.
+                        pasteProxy.focus({ preventScroll: true });
+                        if (document.activeElement === pasteProxy) {
+                            pasteExpected = true;
+                            document.execCommand('paste');
+                            pasteExpected = false; // reset if execCommand did not dispatch synchronously
+                        }
+
+                        // Schedule cleanup in case execCommand did not fire the paste event
+                        if (pasteProxy.isConnected)
+                            setTimeout(() => { if (pasteProxy.textContent) pasteProxy.textContent = ''; pasteProxy.remove(); }, 1000);
 
                         setTimeout(async () => {
                             const files = await readClipboardFiles().catch(() => []);

--- a/init.js
+++ b/init.js
@@ -945,8 +945,9 @@ async function ctrlV(event) {
         event.preventDefault();
         if (ctrlVdata && ctrlVdata.files) {
             const fileList = new DataTransfer();
-            // Include previously selected files for multi-file
-            [...originalInput.files].forEach(file => fileList.items.add(file));
+            // Preserve existing files only for multi-file inputs.
+            if (shouldAppendExistingFiles(originalInput))
+                [...originalInput.files].forEach(file => fileList.items.add(file));
 
             // Append pasted files
             const readPromise = [...ctrlVdata.files]
@@ -1086,6 +1087,10 @@ function clipboardFileName(file) {
     return 'CnP_' + new Date().toLocaleString('en-GB', { hour12: false }).replace(/, /g, '_').replace(/[\/: ]/g, '') + '.' + extension;
 }
 
+function shouldAppendExistingFiles(input) {
+    return !!(input && (input.multiple || input.webkitdirectory));
+}
+
 async function readClipboardFiles() {
     if (!navigator.clipboard || typeof navigator.clipboard.read !== 'function')
         return [];
@@ -1137,7 +1142,8 @@ async function renderClipboardFiles(files, overlay, overlayFileInput) {
     };
 
     const fileList = new DataTransfer();
-    [...originalInput.files].forEach(file => fileList.items.add(file));
+    if (shouldAppendExistingFiles(originalInput))
+        [...originalInput.files].forEach(file => fileList.items.add(file));
 
     const badge = overlay.querySelector('.cnp-preview-badge');
     var isFirstFile = true;
@@ -1564,8 +1570,9 @@ function createOverlay(event) {
                         overlayFileInput.oncancel = () => closeOverlay();
                         overlayFileInput.onchange = event => {
                             const fileList = new DataTransfer();
-                            // Reattach previous files and append new ones
-                            [...originalInput.files, ...event.target.files].forEach(file => fileList.items.add(file));
+                            if (shouldAppendExistingFiles(originalInput))
+                                [...originalInput.files].forEach(file => fileList.items.add(file));
+                            [...event.target.files].forEach(file => fileList.items.add(file));
                             originalInput.files = fileList.files;
                             triggerChangeEvent(originalInput);
                             closeOverlay();
@@ -1625,9 +1632,11 @@ function createOverlay(event) {
                             event.preventDefault();
                             CNP_dropText.style.display = 'none';
                             const fileList = new DataTransfer();
-                            // Reattach previous files and append new ones
+                            // Preserve existing files only for multi-file inputs.
                             const excludedFolders = [...event.dataTransfer.files].filter(file => !(file.size === 0 && file.type === ''));
-                            [...originalInput.files, ...excludedFolders].forEach(file => fileList.items.add(file));
+                            if (shouldAppendExistingFiles(originalInput))
+                                [...originalInput.files].forEach(file => fileList.items.add(file));
+                            [...excludedFolders].forEach(file => fileList.items.add(file));
                             originalInput.files = fileList.files;
                             triggerChangeEvent(originalInput);
                             closeOverlay();

--- a/init.js
+++ b/init.js
@@ -2,24 +2,421 @@
 Initializes global variables and functions.
 */
 
+try {
+    document.documentElement.dataset.cnpInitLoaded = 'true';
+    if (!(typeof chrome !== 'undefined' && chrome.runtime))
+        document.documentElement.dataset.cnpPageHookLoaded = 'true';
+} catch (e) { }
+
+var isPageWorld = !(typeof chrome !== 'undefined' && chrome.runtime);
+var cnpNativeFunctionStrings = window.cnpNativeFunctionStrings || new WeakMap();
+window.cnpNativeFunctionStrings = cnpNativeFunctionStrings;
+var cnpOriginalFunctionToString = window.cnpOriginalFunctionToString || Function.prototype.toString;
+window.cnpOriginalFunctionToString = cnpOriginalFunctionToString;
+
+if (!Function.prototype.cnpMirrorsNativeFunctions) {
+    const mirroredFunctionToString = {
+        toString() {
+            if (cnpNativeFunctionStrings.has(this))
+                return cnpNativeFunctionStrings.get(this);
+
+            return cnpOriginalFunctionToString.call(this);
+        }
+    }.toString;
+    cnpNativeFunctionStrings.set(mirroredFunctionToString, cnpOriginalFunctionToString.call(cnpOriginalFunctionToString));
+    Function.prototype.toString = mirrorNativeFunction(mirroredFunctionToString, cnpOriginalFunctionToString);
+    Object.defineProperty(Function.prototype, 'cnpMirrorsNativeFunctions', {
+        value: true,
+        configurable: true
+    });
+}
+
+function mirrorNativeFunction(wrapper, original) {
+    try {
+        Object.defineProperty(wrapper, 'name', {
+            value: original.name,
+            configurable: true
+        });
+        Object.defineProperty(wrapper, 'length', {
+            value: original.length,
+            configurable: true
+        });
+        cnpNativeFunctionStrings.set(wrapper, cnpOriginalFunctionToString.call(original));
+    } catch (e) { }
+    return wrapper;
+}
+
+function isCnPFileInput(element) {
+    return element && element.matches && element.matches("input[type='file']") && !element.id.toLowerCase().startsWith('cnp');
+}
+
+function findActivatedFileInput(event) {
+    const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
+    const pathInput = path.find(node => isCnPFileInput(node));
+    if (pathInput)
+        return pathInput;
+
+    const label = path.find(node => node && node.tagName === 'LABEL');
+    if (!label)
+        return null;
+
+    if (isCnPFileInput(label.control))
+        return label.control;
+
+    if (label.querySelector) {
+        const nestedInput = label.querySelector("input[type='file']");
+        if (isCnPFileInput(nestedInput))
+            return nestedInput;
+    }
+
+    return null;
+}
+
+function requestIsolatedOverlayForFileInput(input) {
+    try {
+        if (navigator.userActivation && !navigator.userActivation.isActive)
+            return false;
+
+        input.dataset.cnpPageActivation = String(Date.now());
+        input.dispatchEvent(new CustomEvent('cnp-page-file-input-activated', { bubbles: true, composed: true }));
+        return true;
+    } catch (e) {
+        logging(e);
+        return false;
+    }
+}
+
+function filePickerAcceptFromOptions(options) {
+    if (!options || !Array.isArray(options.types))
+        return '';
+
+    const accept = new Set();
+    options.types.forEach(type => {
+        if (!type || !type.accept)
+            return;
+
+        Object.keys(type.accept).forEach(mimeType => {
+            accept.add(mimeType);
+            const extensions = Array.isArray(type.accept[mimeType]) ? type.accept[mimeType] : [];
+            extensions.forEach(extension => accept.add(extension));
+        });
+    });
+    return [...accept].join(',');
+}
+
+function fileSystemHandleForFile(file) {
+    const handle = {
+        kind: 'file',
+        name: file.name,
+        getFile: () => Promise.resolve(file),
+        isSameEntry: other => Promise.resolve(other === handle)
+    };
+    return handle;
+}
+
+function visibleElement(element) {
+    if (!element || !element.getBoundingClientRect)
+        return false;
+
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+}
+
+function isCnPElement(element) {
+    return !!(element && element.closest && element.closest('.cnp-overlay, .cnp-overlay-content'));
+}
+
+function dispatchFilesToDropTarget(target, files) {
+    const dataTransfer = new DataTransfer();
+    [...files].forEach(file => dataTransfer.items.add(file));
+
+    ['dragenter', 'dragover', 'drop'].forEach(type => {
+        target.dispatchEvent(new DragEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer
+        }));
+    });
+}
+
+function filesToFileList(files) {
+    const dataTransfer = new DataTransfer();
+    [...files].forEach(file => dataTransfer.items.add(file));
+    return dataTransfer.files;
+}
+
+var pendingPickerlessFiles = null;
+var pendingPickerlessFallback = null;
+
+function clearPendingPickerlessFiles() {
+    if (pendingPickerlessFallback)
+        clearTimeout(pendingPickerlessFallback);
+
+    pendingPickerlessFallback = null;
+    pendingPickerlessFiles = null;
+}
+
+function fulfillPendingPickerlessInput(input) {
+    if (!pendingPickerlessFiles || !input || input.type !== 'file')
+        return false;
+
+    const files = pendingPickerlessFiles;
+    clearPendingPickerlessFiles();
+    input.files = filesToFileList(input.multiple ? files : files.slice(0, 1));
+    triggerChangeEvent(input);
+    return true;
+}
+
+function replayPickerlessUpload(control, dropTarget, files) {
+    if (!control || files.length === 0)
+        return false;
+
+    pendingPickerlessFiles = files;
+    pendingPickerlessFallback = setTimeout(() => {
+        if (!pendingPickerlessFiles)
+            return;
+
+        const fallbackFiles = pendingPickerlessFiles;
+        clearPendingPickerlessFiles();
+        dispatchFilesToDropTarget(dropTarget, fallbackFiles);
+    }, 1200);
+
+    try {
+        control.click();
+    } catch (e) {
+        clearPendingPickerlessFiles();
+        dispatchFilesToDropTarget(dropTarget, files);
+    }
+    return true;
+}
+
+function findDropTarget(control) {
+    const candidates = [...document.querySelectorAll('body *')]
+        .filter(element => !isCnPElement(element) && visibleElement(element) && /\b(drag|drop)\b.+\b(file|photo|image|here)\b/i.test(element.innerText || element.textContent || ''));
+
+    if (candidates.length > 0)
+        return candidates.sort((a, b) => {
+            const aRect = a.getBoundingClientRect();
+            const bRect = b.getBoundingClientRect();
+            return (aRect.width * aRect.height) - (bRect.width * bRect.height);
+        })[0];
+
+    return control.closest('[role="dialog"]') || document.body;
+}
+
+function isPickerlessUploadButton(element) {
+    if (!element || !element.matches || !visibleElement(element) || isCnPElement(element))
+        return false;
+    if (!element.matches('button, a, label, [role="button"], .media-editor-file-selector__upload-media-button'))
+        return false;
+    if (element.matches('[role="dialog"], [role="tab"], [data-test-modal]'))
+        return false;
+
+    const text = `${element.getAttribute('aria-label') || ''} ${element.innerText || element.textContent || ''}`.trim();
+    return /\b(upload from computer|choose file|select file|browse files?)\b/i.test(text);
+}
+
+function findPickerlessUploadControl(event) {
+    const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
+    if (path.some(node => isCnPElement(node)))
+        return null;
+    if (path.some(node => node && node.getAttribute && node.getAttribute('role') === 'tab'))
+        return null;
+    if (findActivatedFileInput(event))
+        return null;
+
+    return path.find(node => isPickerlessUploadButton(node));
+}
+
+function openOverlayForDropUpload(control) {
+    const dropTarget = findDropTarget(control);
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = /\b(photo|picture|image)\b/i.test(document.body.innerText || '') ? 'image/*' : '';
+    input.dataset.cnpPickerProxy = 'true';
+    input.style.display = 'none';
+
+    input.addEventListener('change', () => {
+        const files = [...input.files];
+        input.remove();
+        if (files.length > 0)
+            replayPickerlessUpload(control, dropTarget, files);
+    }, { once: true });
+    input.addEventListener('cnp-overlay-cancelled', () => input.remove(), { once: true });
+
+    (document.body || document.documentElement).appendChild(input);
+    if (!requestIsolatedOverlayForFileInput(input)) {
+        input.remove();
+        return false;
+    }
+
+    return true;
+}
+
+function openOverlayForFilePicker(options, fallback) {
+    if (pendingPickerlessFiles) {
+        const files = pendingPickerlessFiles;
+        clearPendingPickerlessFiles();
+        return Promise.resolve(files.map(fileSystemHandleForFile));
+    }
+
+    if (navigator.userActivation && !navigator.userActivation.isActive)
+        return fallback.call(window, options);
+
+    return new Promise((resolve, reject) => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = filePickerAcceptFromOptions(options);
+        input.multiple = !!(options && options.multiple);
+        input.dataset.cnpPickerProxy = 'true';
+        input.style.display = 'none';
+
+        const cleanup = () => input.remove();
+        input.addEventListener('change', () => {
+            const files = [...input.files];
+            cleanup();
+            resolve(files.map(fileSystemHandleForFile));
+        }, { once: true });
+        input.addEventListener('cnp-overlay-cancelled', () => {
+            cleanup();
+            reject(new DOMException('The user aborted a request.', 'AbortError'));
+        }, { once: true });
+
+        (document.body || document.documentElement).appendChild(input);
+        if (!requestIsolatedOverlayForFileInput(input)) {
+            cleanup();
+            fallback.call(window, options).then(resolve, reject);
+        }
+    });
+}
+
+function preventNativeFileActivation(event) {
+    if (!isPageWorld || !event.isTrusted)
+        return;
+
+    const fileInput = findActivatedFileInput(event);
+    if (!fileInput || !requestIsolatedOverlayForFileInput(fileInput))
+        return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (typeof event.stopImmediatePropagation === 'function')
+        event.stopImmediatePropagation();
+}
+
+function preventPickerlessUploadActivation(event) {
+    if (!isPageWorld || !event.isTrusted)
+        return;
+
+    const control = findPickerlessUploadControl(event);
+    if (!control || !openOverlayForDropUpload(control))
+        return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (typeof event.stopImmediatePropagation === 'function')
+        event.stopImmediatePropagation();
+}
+
+if (isPageWorld && !document.cnpPageFileActivationListener) {
+    document.cnpPageFileActivationListener = true;
+    document.addEventListener('click', preventNativeFileActivation, true);
+    document.addEventListener('click', preventPickerlessUploadActivation, true);
+}
+
+if (isPageWorld && typeof window.showOpenFilePicker === 'function' && !window.cnpShowOpenFilePicker) {
+    window.cnpShowOpenFilePicker = true;
+    var oriShowOpenFilePicker = window.showOpenFilePicker;
+    window.showOpenFilePicker = mirrorNativeFunction({
+        showOpenFilePicker(options) {
+            return openOverlayForFilePicker(options, oriShowOpenFilePicker);
+        }
+    }.showOpenFilePicker, oriShowOpenFilePicker);
+}
+
+function openOverlayForFileInput(input) {
+    setupcreateOverlay(input);
+    createOverlay({
+        target: input,
+        preventDefault: () => { },
+        stopPropagation: () => { }
+    });
+}
+
 // Detect and override input elements that uses .click()
 var oriClick = HTMLElement.prototype.click;
-HTMLElement.prototype.click = function (...args) {
-    if (this.matches("input[type='file']") && !this.id.toLowerCase().startsWith('cnp')) {
-        setupcreateOverlay(this);
-        oriClick.call(this, ...args);
-    } else
-        return oriClick.apply(this, arguments);
-};
+HTMLElement.prototype.click = mirrorNativeFunction({
+    click(...args) {
+        if (isCnPFileInput(this)) {
+            if (isPageWorld) {
+                if (fulfillPendingPickerlessInput(this))
+                    return;
+
+                if (requestIsolatedOverlayForFileInput(this))
+                    return;
+
+                return oriClick.apply(this, args);
+            }
+
+            openOverlayForFileInput(this);
+            return;
+        } else
+            return oriClick.apply(this, args);
+    }
+}.click, oriClick);
+
+var oriInputClick = HTMLInputElement.prototype.click;
+HTMLInputElement.prototype.click = mirrorNativeFunction({
+    click(...args) {
+        if (isCnPFileInput(this)) {
+            if (isPageWorld) {
+                if (fulfillPendingPickerlessInput(this))
+                    return;
+
+                if (requestIsolatedOverlayForFileInput(this))
+                    return;
+
+                if (typeof oriInputClick === 'function')
+                    return oriInputClick.apply(this, args);
+
+                return oriClick.apply(this, args);
+            }
+
+            openOverlayForFileInput(this);
+            return;
+        } else if (typeof oriInputClick === 'function')
+            return oriInputClick.apply(this, args);
+        else
+            return oriClick.apply(this, args);
+    }
+}.click, oriInputClick || oriClick);
 
 // Detect and override input elements that uses .showPicker()
 var oriShowPicker = HTMLInputElement.prototype.showPicker;
-HTMLInputElement.prototype.showPicker = function () {
-    if (this.matches("input[type='file']"))
-        this.click();
-    else
-        return oriShowPicker.apply(this, arguments);
-};
+HTMLInputElement.prototype.showPicker = mirrorNativeFunction({
+    showPicker(...args) {
+        if (isCnPFileInput(this)) {
+            if (isPageWorld) {
+                if (fulfillPendingPickerlessInput(this))
+                    return;
+
+                if (requestIsolatedOverlayForFileInput(this))
+                    return;
+
+                if (typeof oriShowPicker === 'function')
+                    return oriShowPicker.apply(this, args);
+
+                return oriClick.apply(this, args);
+            }
+
+            openOverlayForFileInput(this);
+        } else if (typeof oriShowPicker === 'function')
+            return oriShowPicker.apply(this, args);
+        else
+            return oriClick.apply(this, args);
+    }
+}.showPicker, oriShowPicker || oriClick);
 
 // Global variables
 var clientX = 0;
@@ -203,21 +600,7 @@ function previewImage(webCopiedImgSrc, readerEvent, blob, requestedOverlayID) {
         imagePreview = document.createElement('img');
         imagePreview.id = 'cnp-image-preview';
         imagePreview.style.height = '50%';
-        try {
-            imagePreview.src = safeGetURL(`media/${fileTypeIcon}.webp`);
-        } catch {
-            try {
-                if (document.head.querySelector('script:is([id*="CnP-mutatedIframe"], [id*="CnP-iframe"])'))
-                    window.top.postMessage({ 'Type': 'getURL', 'iframe': document.head.querySelector('script:is([id*="CnP-mutatedIframe"], [id*="CnP-iframe"])').getAttribute('id'), 'Path': `media/${fileTypeIcon}.webp` }, '*');
-                else
-                    window.top.postMessage({ 'Type': 'getURL', 'Path': `media/${fileTypeIcon}.webp` }, '*');
-
-                window.onmessage = event => {
-                    if (event.data.Type == 'getURL-response')
-                        imagePreview.src = event.data.URL;
-                }
-            } catch (error) { logging(error) }
-        }
+        imagePreview.src = safeGetURL(`media/${fileTypeIcon}.webp`);
         try { imagePreviewContainer.appendChild(imagePreview) } catch (error) { logging(error) }
 
         let title = document.createElement('span');
@@ -246,6 +629,380 @@ function previewImage(webCopiedImgSrc, readerEvent, blob, requestedOverlayID) {
     //   fileName = fileName.replace('.png', '.gif');
 }
 
+function usableClipboardFiles(files) {
+    return [...files].filter(file => !(file.size === 0 && file.type === ''));
+}
+
+function clipboardFileName(file) {
+    if (file.name && file.name !== 'image.png')
+        return file.name;
+
+    const extension = file.type && file.type.includes('/') ? file.type.split('/').pop() : 'bin';
+    return 'CnP_' + new Date().toLocaleString('en-GB', { hour12: false }).replace(/, /g, '_').replace(/[\/: ]/g, '') + '.' + extension;
+}
+
+async function readClipboardFiles() {
+    if (!navigator.clipboard || typeof navigator.clipboard.read !== 'function')
+        return [];
+
+    const clipboardItems = await navigator.clipboard.read();
+    const files = [];
+    for (const item of clipboardItems) {
+        for (const type of item.types || []) {
+            if (type === 'text/plain' || type === 'text/html')
+                continue;
+
+            const blob = await item.getType(type);
+            if (blob && !(blob.size === 0 && blob.type === ''))
+                files.push(new File([blob], clipboardFileName(blob), { type: blob.type, lastModified: Date.now() }));
+        }
+    }
+    return files;
+}
+
+async function renderClipboardFiles(files, overlay, overlayFileInput) {
+    const clipboardFiles = usableClipboardFiles(files);
+    if (clipboardFiles.length == 0) {
+        noImage();
+        return false;
+    }
+
+    ctrlVdata = { files: clipboardFiles };
+
+    const statusMap = new Map();
+    statusMap.set('success', 0);
+    statusMap.set('fail', 0);
+
+    const processFiles = file => {
+        return new Promise(resolve => {
+            reader = new FileReader();
+            reader.onload = readerEvent => {
+                let webCopiedImgSrc = '';
+                previewImage(webCopiedImgSrc, readerEvent, file, overlay.id);
+                statusMap.set('success', statusMap.get('success') + 1);
+                resolve();
+            };
+            reader.onerror = () => {
+                statusMap.set('fail', statusMap.get('fail') + 1);
+                resolve();
+            };
+            reader.onabort = () => { return };
+            reader.readAsArrayBuffer(file);
+        });
+    };
+
+    const fileList = new DataTransfer();
+    [...originalInput.files].forEach(file => fileList.items.add(file));
+
+    const badge = overlay.querySelector('.cnp-preview-badge');
+    var isFirstFile = true;
+    const readPromises = clipboardFiles.map(file => {
+        const filename = clipboardFileName(file);
+
+        badge.title += filename + '\n';
+        badge.innerText = parseInt(badge.innerText) + 1;
+        if (parseInt(badge.innerText) > 1)
+            badge.style.display = 'inline-block';
+
+        const renamedFile = new File([file], filename, { type: file.type, lastModified: file.lastModified });
+        fileList.items.add(renamedFile);
+
+        if (isFirstFile) {
+            isFirstFile = false;
+            return processFiles(renamedFile);
+        }
+    });
+    await Promise.all(readPromises);
+
+    if (statusMap.get('fail') >= 1 && statusMap.get('success') <= 0) {
+        noImage();
+        return false;
+    }
+
+    const imagePreviewContainer = overlay.querySelector('#cnp-preview-container');
+    imagePreviewContainer.style.cursor = 'pointer';
+    imagePreviewContainer.onclick = () => {
+        originalInput.files = fileList.files;
+        triggerChangeEvent(originalInput);
+        closeOverlay();
+    };
+    return true;
+}
+
+function ensureOverlayStyles() {
+    if (document.getElementById('cnp-overlay-style'))
+        return;
+
+    const style = document.createElement('style');
+    style.id = 'cnp-overlay-style';
+    style.textContent = `
+        .cnp-overlay-content {
+            all: initial;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+            font-size: medium;
+            position: absolute;
+            transform: translate(-50%, -50%);
+            background-color: rgba(240, 240, 240, .75);
+            backdrop-filter: blur(15px);
+            border: 1px solid #bebebe;
+            border-radius: 8px;
+            box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.35), 0 0 6px rgba(0, 0, 0, 0);
+            text-align: center;
+            color: #212529;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            line-height: 1.25;
+            z-index: 2147483647;
+        }
+
+        .cnp-overlay-content * {
+            font-family: inherit !important;
+            font-size: inherit !important;
+            line-height: 1.25 !important;
+        }
+
+        .cnp-hr {
+            width: 100%;
+            height: 0px;
+            margin: 7px 0;
+            color: inherit;
+            opacity: .25;
+            border: 0;
+            border-top: .5px solid;
+            padding: 0;
+        }
+
+        #cnp-drop-text {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            font-weight: normal;
+            background-color: rgb(100, 100, 100);
+            color: white;
+            display: none;
+            justify-content: center;
+            align-items: center;
+            border: 2px dashed #ffffff;
+            border-radius: 8px;
+            pointer-events: none;
+            box-sizing: border-box;
+            z-index: 1;
+        }
+
+        #cnp-drop-text svg {
+            margin-right: 7px;
+        }
+
+        .cnp-preview-badge {
+            display: none;
+            line-height: 0.85;
+            word-break: normal;
+            position: absolute;
+            top: 4%;
+            left: 98%;
+            transform: translate(-50%, -50%);
+            background-color: rgba(240, 240, 240);
+            backdrop-filter: blur(15px);
+            border: 1px solid #bebebe;
+            color: #212529;
+            font-size: 1.1em;
+            font-weight: 400;
+            padding: 0.3em 0.5em;
+            text-align: center;
+            border-radius: 8px;
+        }
+
+        #cnp-preview-container {
+            width: 272px;
+            height: 153px;
+            margin-top: 7px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+        }
+
+        #cnp-preview-container:hover {
+            background-color: rgba(0, 0, 0, .1);
+            filter: brightness(.9);
+        }
+
+        #cnp-image-preview {
+            position: relative;
+            max-width: 100%;
+            max-height: 100%;
+            object-fit: cover;
+            pointer-events: none;
+            border: 0;
+            margin: 0;
+        }
+
+        #cnp-image-title {
+            pointer-events: none;
+            font-size: 14px;
+            font-weight: normal;
+        }
+
+        #cnp-not-image {
+            font-weight: lighter;
+        }
+
+        #cnp-overlay-file-input {
+            display: none;
+        }
+
+        #cnp-upload {
+            font-weight: normal;
+        }
+
+        #cnp-upload svg {
+            display: inline;
+        }
+
+        .cnp-menu-item {
+            cursor: default;
+            margin-bottom: 7px;
+            padding: 6px;
+        }
+
+        .cnp-menu-item:hover {
+            background-color: rgba(0, 0, 0, .1);
+        }
+
+        .cnp-bi {
+            vertical-align: -.125em;
+        }
+
+        .cnp-spinner {
+            display: block;
+            position: absolute;
+            border: 8px solid #e0e0e0;
+            border-radius: 100%;
+            border-top: 8px solid #00000000;
+            width: 60px;
+            height: 60px;
+            -webkit-animation: spin .85s linear infinite;
+            animation: spin .85s linear infinite;
+        }
+
+        @-webkit-keyframes spin {
+            0% { -webkit-transform: rotate(0deg); }
+            100% { -webkit-transform: rotate(360deg); }
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .cnp-overlay-content {
+                background-color: rgba(25, 25, 25, .85);
+                border: 1px solid #444449;
+                color: white;
+                backdrop-filter: blur(50px);
+            }
+
+            #cnp-preview-container:hover {
+                background-color: rgba(255, 255, 255, .1);
+                filter: brightness(.9);
+            }
+
+            .cnp-menu-item:hover {
+                background-color: rgba(255, 255, 255, .1);
+            }
+
+            .cnp-spinner {
+                border-color: #505050;
+                border-top-color: #00000000;
+            }
+
+            .cnp-preview-badge {
+                background-color: rgb(57 57 57);
+                backdrop-filter: blur(50px);
+                border: 1px solid #444449;
+                color: white;
+            }
+        }
+    `;
+    document.head.appendChild(style);
+}
+
+function appendPlusIcon(parent) {
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('xmlns', svgNS);
+    svg.setAttribute('width', '16');
+    svg.setAttribute('height', '16');
+    svg.setAttribute('fill', 'currentColor');
+    svg.setAttribute('class', 'cnp-bi bi-plus-lg');
+    svg.setAttribute('viewBox', '0 0 16 16');
+
+    const path = document.createElementNS(svgNS, 'path');
+    path.setAttribute('fill-rule', 'evenodd');
+    path.setAttribute('d', 'M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2');
+
+    svg.appendChild(path);
+    parent.appendChild(svg);
+}
+
+function buildOverlayContent(overlay) {
+    ensureOverlayStyles();
+
+    const content = document.createElement('div');
+    content.className = 'cnp-overlay-content';
+
+    const dropText = document.createElement('span');
+    dropText.id = 'cnp-drop-text';
+    appendPlusIcon(dropText);
+    dropText.appendChild(document.createTextNode('Drop files here'));
+    content.appendChild(dropText);
+
+    const previewContainer = document.createElement('div');
+    previewContainer.id = 'cnp-preview-container';
+    const spinner = document.createElement('div');
+    spinner.className = 'cnp-spinner';
+    previewContainer.appendChild(spinner);
+    content.appendChild(previewContainer);
+
+    const badge = document.createElement('span');
+    badge.className = 'cnp-preview-badge';
+    badge.textContent = '0';
+    content.appendChild(badge);
+
+    const divider = document.createElement('hr');
+    divider.className = 'cnp-hr';
+    content.appendChild(divider);
+
+    const overlayFileInput = document.createElement('input');
+    overlayFileInput.type = 'file';
+    overlayFileInput.id = 'cnp-overlay-file-input';
+    content.appendChild(overlayFileInput);
+
+    const uploadBtn = document.createElement('div');
+    uploadBtn.id = 'cnp-upload-btn';
+    uploadBtn.className = 'cnp-menu-item';
+
+    const upload = document.createElement('span');
+    upload.id = 'cnp-upload';
+    appendPlusIcon(upload);
+    upload.appendChild(document.createTextNode(' '));
+
+    const uploadText = document.createElement('span');
+    uploadText.id = 'cnp-upload-text';
+    uploadText.textContent = 'Upload File';
+    upload.appendChild(uploadText);
+    uploadBtn.appendChild(upload);
+    content.appendChild(uploadBtn);
+
+    overlay.appendChild(content);
+    return content;
+}
+
 // When prepped input elements are clicked
 function createOverlay(event) {
     // Check if overlay is already visible for this input
@@ -261,130 +1018,25 @@ function createOverlay(event) {
 
     // First click - prevent default and show overlay
     event.preventDefault();
+    event.stopPropagation();
     originalInput = event.target;
 
     // Create overlay
     const overlay = document.createElement('div');
     overlay.classList.add('cnp-overlay');
+    overlay.dataset.cnpIgnoreCloseUntil = String(Date.now() + 250);
 
     // Unique ID for each created overlay
     const hexArray = Array.from(crypto.getRandomValues(new Uint8Array(16))).map(byte => byte.toString(16).padStart(2, '0'));
     const uuid = [hexArray.slice(0, 4).join(''), hexArray.slice(4, 6).join(''), '4' + hexArray.slice(6, 7).join(''), (parseInt(hexArray[8], 16) & 0x3 | 0x8).toString(16) + hexArray.slice(9, 11).join(''), hexArray.slice(11, 16).join('')].join('-');
     overlay.id = overlayID = uuid;
 
-    // Fetch overlay.html
-    function fetchURL() {
-        return new Promise(resolve => {
-            var urlToFetch = null;
-            if (document.head.querySelector('script[overlayhtml]')) {
-                urlToFetch = document.head.querySelector('script[overlayhtml]').getAttribute('overlayhtml');
-                resolve(urlToFetch);
-            }
-            else if (!urlToFetch && typeof chrome.runtime !== 'undefined')
-                try {
-                    urlToFetch = safeGetURL('overlay.html');
-                    resolve(urlToFetch);
-                }
-                catch {
-                    if (document.head.querySelector('script:is([id*="CnP-mutatedIframe"], [id*="CnP-iframe"])'))
-                        window.top.postMessage({ 'Type': 'getURL', 'iframe': document.head.querySelector('script:is([id*="CnP-mutatedIframe"], [id*="CnP-iframe"])').getAttribute('id'), 'Path': 'overlay.html' }, '*');
-                    else
-                        window.top.postMessage({ 'Type': 'getURL', 'Path': 'overlay.html' }, '*');
-                    window.onmessage = event => {
-                        if (event.data.Type == 'getURL-response') {
-                            urlToFetch = event.data.URL;
-                            resolve(urlToFetch);
-                        }
-                    }
-                }
-            else if (document.head.querySelector('copy-n-paste'))
-                try {
-                    urlToFetch = document.head.querySelector('copy-n-paste').getAttribute('overlay-html');
-                    resolve(urlToFetch);
-                } catch (error) { logging(error) }
-            else
-                resolve(urlToFetch);
-        });
-    }
-
     try {
-        fetchURL().then(urlToFetch => {
-            if (urlToFetch) {
-                fetch(urlToFetch)
-                    .then(response => response.text())
-                    .then(html => {
-                        // Prevents duplicate overlay setup
-                        if (document.querySelector('.cnp-overlay'))
-                            return;
+        // Prevents duplicate overlay setup
+        if (document.querySelector('.cnp-overlay'))
+            return;
 
-                        // Insert overlay HTML safely: prefer parsing and appending nodes (avoids innerHTML sinks),
-                        // fall back to TrustedTypes only if parsing doesn't find expected content.
-                        function insertOverlayHtml(overlayElem, htmlString) {
-                            try {
-                                let parsed;
-                                try {
-                                    parsed = new DOMParser().parseFromString(htmlString, 'text/html');
-                                } catch (parseErr) {
-                                    // Some hosts require TrustedHTML; DOMParser will throw. Treat as parse failure silently
-                                    // to avoid noisy console logs — fall back to TrustedTypes / innerHTML below.
-                                    parsed = null;
-                                    // Only log non-TrustedHTML parse errors
-                                    if (parseErr && !(parseErr.message && parseErr.message.includes('TrustedHTML')))
-                                        logging(parseErr);
-                                }
-                                // Prefer the main overlay content element from the parsed document, if parsing succeeded
-                                if (parsed) {
-                                    const content = parsed.querySelector('.cnp-overlay-content');
-                                    if (content) {
-                                        // Preserve the wrapper element so later queries for .cnp-overlay-content work
-                                        // Also copy any <style> or <link rel="stylesheet"> into the top-level document head
-                                        const styles = parsed.querySelectorAll('style, link[rel="stylesheet"]');
-                                        styles.forEach(s => {
-                                            try {
-                                                document.head.appendChild(s.cloneNode(true));
-                                            } catch (e) { logging(e) }
-                                        });
-
-                                        overlayElem.appendChild(content.cloneNode(true));
-                                        return true;
-                                    }
-
-                                    const sourceContainer = parsed.body;
-                                    if (sourceContainer) {
-                                        // No wrapper found; append body children only
-                                        Array.from(sourceContainer.children).forEach(child => overlayElem.appendChild(child.cloneNode(true)));
-                                        return true;
-                                    }
-                                }
-                            } catch (e) { logging(e) }
-
-                            // If parsing didn't work or didn't contain expected content, try TrustedTypes only on
-                            // Google Docs / Slides (they require TrustedHTML). This avoids triggering CSP refusal
-                            // logs on other sites like LinkedIn.
-                            try {
-                                const trustedHTMLNeeded = docRequiresTrustedHTML();
-                                const blobAllowed = docAllowsBlobScripts();
-                                if (!isFirefox && trustedHTMLNeeded && window.trustedTypes && typeof trustedTypes.createPolicy === 'function') {
-                                    try {
-                                        const policy = trustedTypes.createPolicy("forceInner", { createHTML: (to_escape) => to_escape });
-                                        overlayElem.innerHTML = policy.createHTML(htmlString);
-                                        return true;
-                                    } catch (e) { logging(e) }
-                                }
-
-                                // Otherwise use safe shim (no-op) so we don't attempt to create policies on pages that block them
-                                if (!isFirefox) {
-                                    const trusted = getTrustedPolicy("forceInner", { createHTML: (to_escape) => to_escape }).createHTML(htmlString);
-                                    overlayElem.innerHTML = trusted;
-                                    return true;
-                                }
-                            } catch (e) { logging(e) }
-
-                            // Last resort: raw assignment (may still be blocked by CSP)
-                            try { overlayElem.innerHTML = htmlString; return true } catch (e) { logging(e); return false }
-                        }
-
-                        insertOverlayHtml(overlay, html);
+        buildOverlayContent(overlay);
 
                         document.body.appendChild(overlay);
                         // Ensure overlay floats above page content even if page CSS wasn't copied
@@ -446,6 +1098,10 @@ function createOverlay(event) {
                             document.addEventListener('click', event => {
                                 document.cnpRemoveListener = true;
                                 document.querySelectorAll('.cnp-overlay-content').forEach(overlayContent => {
+                                    const overlay = overlayContent.closest('.cnp-overlay');
+                                    if (overlay && Date.now() < Number(overlay.dataset.cnpIgnoreCloseUntil || 0))
+                                        return;
+
                                     if (!overlayContent.contains(event.target))
                                         closeOverlay();
                                 })
@@ -481,108 +1137,45 @@ function createOverlay(event) {
                         // Handle Ctrl+V action
                         document.addEventListener('keydown', ctrlV);
 
+                        var isClipboardPreviewResolved = false;
+                        const finishClipboardPreview = () => isClipboardPreviewResolved = true;
+                        const fallbackNoImageTimer = setTimeout(() => {
+                            if (!isClipboardPreviewResolved && document.getElementById(overlay.id)) {
+                                finishClipboardPreview();
+                                noImage();
+                            }
+                        }, 800);
+
                         // Handle paste event
-                        var isPasteListenerTriggered = false;
                         document.addEventListener('paste', async event => {
-                            isPasteListenerTriggered = true;
                             event.stopPropagation();
                             event.preventDefault();
 
-                            const statusMap = new Map();
-                            statusMap.set('success', 0);
-                            statusMap.set('fail', 0);
-                            if (overlayFileInput) {
-                                // Access clipboard to display latest copied files to overlay
-                                const dataTransfer = event.clipboardData;
-                                if (dataTransfer.files.length > 0) {
-                                    ctrlVdata = cloneEvent(event.clipboardData); // Separate paste listener using Ctrl+V
+                            if (isClipboardPreviewResolved || !overlayFileInput)
+                                return;
 
-                                    // Function to handle the FileReader asynchronously
-                                    const processFiles = file => {
-                                        return new Promise(resolve => {
-                                            reader = new FileReader();
-                                            reader.onload = readerEvent => {
-                                                let webCopiedImgSrc = '';
-                                                previewImage(webCopiedImgSrc, readerEvent, file, overlay.id);
-                                                statusMap.set('success', statusMap.get('success') + 1);
-                                                resolve();
-                                            };
-                                            reader.onerror = () => {
-                                                statusMap.set('fail', statusMap.get('fail') + 1);
-                                                resolve();
-                                            };
-                                            reader.onabort = () => { return };
-                                            reader.readAsArrayBuffer(file);
-                                        });
-                                    };
-
-                                    // Reattach previous files for multi-file (continues in imagePreviewContainer.onclick below)
-                                    const fileList = new DataTransfer();
-                                    [...originalInput.files].forEach(file => fileList.items.add(file));
-
-                                    // Array of promises to process each file
-                                    const excludedFolders = [...dataTransfer.files].filter(file => !(file.size === 0 && file.type === ''));
-                                    if (excludedFolders.length == 0) {
-                                        noImage();
-                                        return;
-                                    }
-                                    else {
-                                        const badge = document.querySelector('.cnp-preview-badge');
-                                        var isFirstFile = true;
-                                        const readPromises = [...dataTransfer.files]
-                                            .filter(file => !(file.size === 0 && file.type === ''))
-                                            .map(file => {
-                                                let filename = file.name;
-                                                if (!filename || filename == 'image.png')
-                                                    filename = 'CnP_' + new Date().toLocaleString('en-GB', { hour12: false }).replace(/, /g, '_').replace(/[\/: ]/g, '') + '.' + file.type.split('/').pop();
-
-                                                // Badge counter setup
-                                                badge.title += filename + '\n';
-                                                badge.innerText = parseInt(badge.innerText) + 1;
-                                                if (parseInt(badge.innerText) > 1)
-                                                    badge.style.display = 'inline-block';
-
-                                                fileList.items.add(new File([file], filename, { type: file.type, lastModified: file.lastModified }));
-
-                                                if (isFirstFile) {
-                                                    isFirstFile = false;
-                                                    return processFiles(file);
-                                                }
-                                            });
-                                        await Promise.all(readPromises);
-                                    }
-
-                                    if (statusMap.get('fail') >= 1 && statusMap.get('success') <= 0)
-                                        noImage();
-                                    else {
-                                        const imagePreviewContainer = document.querySelector('#cnp-preview-container');
-                                        imagePreviewContainer.style.cursor = 'pointer';
-                                        imagePreviewContainer.onclick = () => {
-                                            originalInput.files = fileList.files;
-                                            triggerChangeEvent(originalInput);
-                                            closeOverlay();
-                                        };
-                                    }
-                                } else
-                                    noImage();
-                            }
+                            const dataTransfer = event.clipboardData;
+                            ctrlVdata = cloneEvent(event.clipboardData);
+                            finishClipboardPreview();
+                            clearTimeout(fallbackNoImageTimer);
+                            await renderClipboardFiles(dataTransfer.files, overlay, overlayFileInput);
                         }, { once: true, capture: true });
 
                         // Trigger paste event
                         overlay.contentEditable = true;
                         overlay.focus({ preventScroll: true });
                         document.execCommand('paste');
-                        if (!isPasteListenerTriggered)
-                            window.top.postMessage({ 'Type': 'paste' }, '*');
-                        isPasteListenerTriggered = false;
                         overlay.contentEditable = false;
 
-                        // Trigger paste event for iframe
-                        if (document.head.querySelector('script:is([id*="CnP-mutatedIframe"], [id*="CnP-iframe"])'))
-                            window.top.postMessage({ 'Type': 'paste', 'iframe': document.head.querySelector('script:is([id*="CnP-mutatedIframe"], [id*="CnP-iframe"])').getAttribute('id') }, '*');
-                    });
-            }
-        });
+                        setTimeout(async () => {
+                            const files = await readClipboardFiles().catch(() => []);
+                            if (isClipboardPreviewResolved || files.length == 0)
+                                return;
+
+                            finishClipboardPreview();
+                            clearTimeout(fallbackNoImageTimer);
+                            await renderClipboardFiles(files, overlay, overlayFileInput);
+                        }, 50);
     } catch (error) { logging(error) }
 }
 
@@ -631,6 +1224,9 @@ function triggerChangeEvent(originalInput) {
 
 // Close overlay immediate
 function closeOverlay() {
+    if (originalInput && originalInput.dataset && originalInput.dataset.cnpPickerProxy === 'true' && originalInput.files.length === 0)
+        originalInput.dispatchEvent(new CustomEvent('cnp-overlay-cancelled'));
+
     document.querySelectorAll('.cnp-overlay').forEach(overlay => overlay.remove());
     document.removeEventListener('keydown', ctrlV);
     URL.revokeObjectURL(currentObjectURL);
@@ -641,5 +1237,4 @@ function closeOverlay() {
 // Console logging for errors and messages
 function logging(message) {
     console.log('%c📋 Copy-n-Paste:\n', 'font-weight: bold; font-size: 1.3em;', message);
-    window.top.postMessage(('%c📋 Copy-n-Paste:\n', 'font-weight: bold; font-size: 1.3em;', message), '*');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "dependencies": {
         "archiver": "^7.0.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -33,6 +36,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/abort-controller": {
@@ -325,6 +344,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -541,6 +575,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,14 @@
 {
+  "scripts": {
+    "build": "node build.js",
+    "diagnose:sites": "node scripts/diagnose-real-sites.js",
+    "test:sites": "playwright test tests/real-sites.spec.js --reporter=line",
+    "test:smoke": "playwright test tests/extension-smoke.spec.js --reporter=line"
+  },
   "dependencies": {
     "archiver": "^7.0.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0"
   }
 }

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -15,6 +15,8 @@
       {
         "js": ["init.js", "content.js"],
         "all_frames": true,
+        "match_about_blank": true,
+        "match_origin_as_fallback": true,
         "run_at": "document_start",
         "matches": ["<all_urls>"]
       }

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -9,11 +9,13 @@
         "48": "icons/icon48.png",
         "128": "icons/icon128.png"
     },
-    "permissions": ["clipboardRead", "alarms"],
+    "permissions": ["clipboardRead", "alarms", "scripting"],
+    "host_permissions": ["<all_urls>"],
     "content_scripts": [
       {
         "js": ["init.js", "content.js"],
         "all_frames": true,
+        "run_at": "document_start",
         "matches": ["<all_urls>"]
       }
     ],

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -22,6 +22,7 @@
       {
         "js": ["init.js", "content.js"],
         "all_frames": true,
+        "match_about_blank": true,
         "run_at": "document_start",
         "matches": ["<all_urls>"]
       }

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -1,6 +1,12 @@
 {
     "browser_specific_settings": {
-      "gecko": { "id": "kazcfz@copy-n-paste" }
+      "gecko": {
+        "id": "kazcfz@copy-n-paste",
+        "strict_min_version": "140.0",
+        "data_collection_permissions": {
+          "required": ["none"]
+        }
+      }
     },
     "manifest_version": 2,
     "name": "Copy-n-Paste: Clipboard Upload Simplified",
@@ -16,6 +22,7 @@
       {
         "js": ["init.js", "content.js"],
         "all_frames": true,
+        "run_at": "document_start",
         "matches": ["<all_urls>"]
       }
     ],

--- a/scripts/diagnose-real-sites.js
+++ b/scripts/diagnose-real-sites.js
@@ -1,0 +1,361 @@
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('@playwright/test');
+
+const knownTargets = {
+    business: 'https://business.facebook.com/',
+    contacts: 'https://contacts.google.com/new',
+    bsky: 'https://bsky.app/',
+    gemini: 'https://gemini.google.com/app',
+    linkedin: 'https://www.linkedin.com/',
+    photos: 'https://photos.google.com/'
+};
+
+const targets = (process.argv.slice(2).length ? process.argv.slice(2) : ['contacts', 'linkedin', 'bsky', 'gemini'])
+    .map(target => knownTargets[target] || target);
+
+const rootDir = path.resolve(__dirname, '..');
+const extensionPath = path.join(rootDir, 'dist', 'chromium');
+const profileDir = path.resolve(process.env.CNP_PROFILE_DIR || path.join(rootDir, 'playwright-profiles', 'real-sites'));
+const browserChannel = process.env.CNP_BROWSER_CHANNEL || '';
+const interceptFileChooser = process.env.CNP_INTERCEPT_FILE_CHOOSER !== '0';
+const launchArgs = [
+    '--disable-blink-features=AutomationControlled',
+    `--disable-extensions-except=${extensionPath}`,
+    `--load-extension=${extensionPath}`
+];
+
+if (!fs.existsSync(path.join(extensionPath, 'manifest.json'))) {
+    console.error('Missing dist/chromium/manifest.json. Run `npm run build` first.');
+    process.exit(1);
+}
+
+function relativeSelector(element) {
+    if (!element || !element.tagName)
+        return '(unknown)';
+
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < 4) {
+        let part = current.tagName.toLowerCase();
+        if (current.id)
+            part += `#${current.id}`;
+        else {
+            const classes = [...current.classList].slice(0, 3).join('.');
+            if (classes)
+                part += `.${classes}`;
+        }
+        parts.unshift(part);
+        current = current.parentElement;
+    }
+    return parts.join(' > ');
+}
+
+async function installPageDiagnostics(page) {
+    await page.addInitScript(() => {
+        window.__cnpDiagnostics = [];
+        window.__cnpManualStep = 0;
+
+        function relativeSelector(element) {
+            if (!element || !element.tagName)
+                return '(unknown)';
+
+            const parts = [];
+            let current = element;
+            while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < 5) {
+                let part = current.tagName.toLowerCase();
+                if (current.id)
+                    part += `#${current.id}`;
+                else {
+                    const classes = [...current.classList || []].slice(0, 3).join('.');
+                    if (classes)
+                        part += `.${classes}`;
+                }
+                parts.unshift(part);
+                current = current.parentElement;
+            }
+            return parts.join(' > ');
+        }
+
+        function describeElement(element) {
+            if (!element || !element.tagName)
+                return null;
+
+            return {
+                tag: element.tagName.toLowerCase(),
+                id: element.id || '',
+                classes: [...element.classList || []].slice(0, 8),
+                type: element.getAttribute && element.getAttribute('type'),
+                accept: element.getAttribute && element.getAttribute('accept'),
+                multiple: !!element.multiple,
+                hidden: !!element.hidden,
+                display: getComputedStyle(element).display,
+                visibility: getComputedStyle(element).visibility,
+                ariaLabel: element.getAttribute && element.getAttribute('aria-label'),
+                selector: relativeSelector(element),
+                text: (element.innerText || element.textContent || '').trim().slice(0, 120)
+            };
+        }
+
+        function isVisible(element) {
+            if (!element || !element.getBoundingClientRect)
+                return false;
+
+            const rect = element.getBoundingClientRect();
+            const style = getComputedStyle(element);
+            return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+        }
+
+        function isRelevantUploadUi(element) {
+            if (!element || !element.matches)
+                return false;
+
+            if (element.matches('input[type="file"], .cnp-overlay-content, simplified-input-menu, [role="menu"], [role="dialog"]'))
+                return true;
+
+            if (!element.matches('button, a, label, [role="button"], [aria-label], [data-testid], [data-test-id]'))
+                return false;
+
+            const text = [
+                element.id,
+                element.getAttribute('aria-label'),
+                element.getAttribute('title'),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id'),
+                element.innerText || element.textContent || ''
+            ].filter(Boolean).join(' ');
+            return /upload|file|image|photo|media|attach|add/i.test(text);
+        }
+
+        function collectVisibleUploadUi() {
+            return [...document.querySelectorAll('input[type="file"], .cnp-overlay-content, simplified-input-menu, [role="menu"], [role="dialog"], button, a, label, [role="button"], [aria-label], [data-testid], [data-test-id]')]
+                .filter(element => isVisible(element) && isRelevantUploadUi(element))
+                .slice(0, 30)
+                .map(describeElement);
+        }
+
+        function relevantNodes(node) {
+            const nodes = [];
+            if (!node || node.nodeType !== Node.ELEMENT_NODE)
+                return nodes;
+
+            if (isRelevantUploadUi(node))
+                nodes.push(node);
+
+            if (node.querySelectorAll)
+                node.querySelectorAll('input[type="file"], .cnp-overlay-content, simplified-input-menu, [role="menu"], [role="dialog"], button, a, label, [role="button"], [aria-label], [data-testid], [data-test-id]').forEach(element => {
+                    if (isRelevantUploadUi(element))
+                        nodes.push(element);
+                });
+            return nodes.slice(0, 20);
+        }
+
+        function eventPathHasCnPUploadActivation(event) {
+            const path = event.composedPath ? event.composedPath() : [event.target];
+            return path.some(node => node && node.id && (node.id === 'cnp-overlay-file-input' || node.id === 'cnp-upload-btn'));
+        }
+
+        function describePointerHit(event) {
+            if (typeof event.clientX !== 'number' || typeof event.clientY !== 'number')
+                return null;
+
+            return describeElement(document.elementFromPoint(event.clientX, event.clientY));
+        }
+
+        function record(type, detail) {
+            window.__cnpDiagnostics.push({
+                type,
+                url: location.href,
+                time: new Date().toISOString(),
+                detail
+            });
+        }
+
+        ['pointerdown', 'mousedown', 'mouseup', 'click'].forEach(type => {
+            window.addEventListener(type, event => {
+                if (!event.isTrusted || !eventPathHasCnPUploadActivation(event))
+                    return;
+
+                record('overlay-upload-activation-event', {
+                    type,
+                    target: describeElement(event.target),
+                    hitTarget: describePointerHit(event),
+                    cancelable: event.cancelable,
+                    defaultPrevented: event.defaultPrevented,
+                    userActivationActive: !!(navigator.userActivation && navigator.userActivation.isActive),
+                    userActivationHasBeenActive: !!(navigator.userActivation && navigator.userActivation.hasBeenActive)
+                });
+            }, true);
+        });
+
+        const originalCreateElement = Document.prototype.createElement;
+        Document.prototype.createElement = function (...args) {
+            const element = originalCreateElement.apply(this, args);
+            if (String(args[0]).toLowerCase() === 'input') {
+                queueMicrotask(() => {
+                    if (element.type === 'file')
+                        record('create-file-input', describeElement(element));
+                });
+            }
+            return element;
+        };
+
+        const originalClick = HTMLInputElement.prototype.click;
+        HTMLInputElement.prototype.click = function (...args) {
+            if (this.type === 'file')
+                record('input-click', describeElement(this));
+            return originalClick.apply(this, args);
+        };
+
+        if (HTMLInputElement.prototype.showPicker) {
+            const originalShowPicker = HTMLInputElement.prototype.showPicker;
+            HTMLInputElement.prototype.showPicker = function (...args) {
+                if (this.type === 'file')
+                    record('input-showPicker', describeElement(this));
+                return originalShowPicker.apply(this, args);
+            };
+        }
+
+        if (typeof window.showOpenFilePicker === 'function') {
+            const originalShowOpenFilePicker = window.showOpenFilePicker;
+            window.showOpenFilePicker = function (...args) {
+                record('showOpenFilePicker', args[0] || null);
+                return originalShowOpenFilePicker.apply(this, args);
+            };
+        }
+
+        document.addEventListener('click', event => {
+            const path = event.composedPath ? event.composedPath() : [];
+            const fileInput = path.find(node => node && node.tagName === 'INPUT' && node.type === 'file');
+            const label = path.find(node => node && node.tagName === 'LABEL');
+            const button = path.find(node => node && node.tagName && /^(BUTTON|A|DIV|SPAN)$/.test(node.tagName) && (node.innerText || node.getAttribute('aria-label')));
+            if (event.isTrusted) {
+                const step = ++window.__cnpManualStep;
+                record('manual-click', {
+                    step,
+                    target: describeElement(event.target),
+                    visibleUploadUi: collectVisibleUploadUi()
+                });
+                setTimeout(() => record('post-click-ui', {
+                    step,
+                    visibleUploadUi: collectVisibleUploadUi()
+                }), 250);
+            }
+            if (fileInput || label || button)
+                record('document-click', {
+                    target: describeElement(event.target),
+                    fileInput: describeElement(fileInput),
+                    label: describeElement(label),
+                    control: describeElement(button)
+                });
+        }, true);
+
+        const observer = new MutationObserver(mutations => {
+            for (const mutation of mutations) {
+                for (const node of mutation.addedNodes) {
+                    for (const element of relevantNodes(node)) {
+                        if (element.matches('input[type="file"]'))
+                            record('added-file-input', describeElement(element));
+                        else if (element.matches('.cnp-overlay-content'))
+                            record('overlay-added', describeElement(element));
+                        else
+                            record('ui-added', describeElement(element));
+                    }
+                }
+
+                for (const node of mutation.removedNodes) {
+                    for (const element of relevantNodes(node))
+                        record('ui-removed', describeElement(element));
+                }
+            }
+        });
+
+        window.addEventListener('DOMContentLoaded', () => observer.observe(document.documentElement, { childList: true, subtree: true }), { once: true });
+    });
+
+    page.on('console', message => {
+        const text = message.text();
+        if (/Copy-n-Paste|CnP|clipboard|file|upload/i.test(text))
+            console.log(`[console:${message.type()}] ${text}`);
+    });
+
+    if (interceptFileChooser) {
+        page.on('filechooser', async chooser => {
+            console.log(`[filechooser] ${page.url()}`);
+            console.log('  Playwright intercepted the chooser. Set CNP_INTERCEPT_FILE_CHOOSER=0 to let the Windows picker appear during manual diagnostics.');
+        });
+    }
+
+    page.on('framenavigated', frame => {
+        if (frame === page.mainFrame())
+            console.log(`[nav] ${frame.url()}`);
+    });
+}
+
+async function flushDiagnostics(page, label) {
+    try {
+        const events = await page.evaluate(() => {
+            const events = window.__cnpDiagnostics || [];
+            window.__cnpDiagnostics = [];
+            return events;
+        });
+
+        for (const event of events) {
+            console.log(`[${label}] ${event.type} ${event.time}`);
+            console.log(JSON.stringify(event.detail, null, 2));
+        }
+    } catch (error) {
+        console.log(`[${label}] diagnostics unavailable: ${error.message}`);
+    }
+}
+
+(async () => {
+    fs.mkdirSync(profileDir, { recursive: true });
+    console.log(`Using persistent profile: ${profileDir}`);
+    console.log(`Loading extension: ${extensionPath}`);
+    console.log('Using launch flag: --disable-blink-features=AutomationControlled');
+    if (browserChannel)
+        console.log(`Using browser channel: ${browserChannel}`);
+    else
+        console.log('Using bundled Chromium channel; leave CNP_BROWSER_CHANNEL empty for extension diagnostics.');
+    console.log(interceptFileChooser
+        ? 'File chooser diagnostics: Playwright will intercept chooser events for logging.'
+        : 'File chooser diagnostics: native Windows picker is not intercepted by this script.');
+
+    const launchOptions = {
+        headless: false,
+        viewport: null,
+        ignoreDefaultArgs: ['--enable-automation'],
+        args: launchArgs
+    };
+
+    if (browserChannel)
+        launchOptions.channel = browserChannel;
+
+    const context = await chromium.launchPersistentContext(profileDir, launchOptions);
+
+    const pages = [];
+    for (const target of targets) {
+        const page = await context.newPage();
+        await installPageDiagnostics(page);
+        await page.goto(target, { waitUntil: 'domcontentloaded' });
+        pages.push({ page, label: new URL(target).hostname });
+        console.log(`Opened ${target}`);
+    }
+
+    console.log('\nLog in manually if needed, then click the failing upload controls.');
+    console.log('This script will print file-input, filechooser, and CnP overlay events. Press Ctrl+C here when done.\n');
+
+    const interval = setInterval(async () => {
+        for (const entry of pages)
+            await flushDiagnostics(entry.page, entry.label);
+    }, 1000);
+
+    process.on('SIGINT', async () => {
+        clearInterval(interval);
+        for (const entry of pages)
+            await flushDiagnostics(entry.page, entry.label);
+        await context.close();
+        process.exit(0);
+    });
+})();

--- a/tests/extension-smoke.spec.js
+++ b/tests/extension-smoke.spec.js
@@ -1,0 +1,464 @@
+const { test, expect, chromium } = require('@playwright/test');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+async function writeClipboardImage(page) {
+    await page.evaluate(async () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 1;
+        canvas.height = 1;
+        const context = canvas.getContext('2d');
+        context.fillStyle = '#f00';
+        context.fillRect(0, 0, 1, 1);
+        const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+    });
+}
+
+function startServer() {
+    const pages = {
+        '/': `<!doctype html>
+            <html>
+                <body>
+                    <input id="plain" type="file">
+                    <label id="label-upload" for="labeled">Label upload</label>
+                    <input id="labeled" type="file" style="display:none">
+                    <button id="proxy-upload">Proxy upload</button>
+                    <button id="show-picker-upload">Show picker upload</button>
+                    <button id="fs-picker-upload">File System Access upload</button>
+                    <button id="drop-upload">Upload from computer</button>
+                    <button id="display-mode" aria-label="Display Mode">Display Mode</button>
+                    <button id="device-upload-button" type="button">Upload</button>
+                    <button id="upload-from-desktop" type="button">Upload from desktop</button>
+                    <button id="reddit-add-media" rpl="" class="add-media action invisible group-hover:visible">Add</button>
+                    <button id="add-image" aria-label="Add image">Add image</button>
+                    <button id="business-add-photo" aria-label="Add Photo">Add Photo</button>
+                    <button id="add-photo-video">Add photo/video</button>
+                    <button id="add-video-dropdown" aria-haspopup="menu" aria-expanded="false">Add Video</button>
+                    <div id="video-dropdown-menu" role="menu" hidden>
+                        <div id="upload-desktop-menuitem" role="menuitem" tabindex="0">Upload from desktop</div>
+                        <div id="upload-video-edit-menuitem" role="menuitem" tabindex="0">Upload video and edit</div>
+                            <div id="upload-menuitem-early-close" role="menuitem" tabindex="0">Upload images and files</div>
+                    </div>
+                    <button id="attach-file-icon" aria-label="Attach a file" title="Attach a file"></button>
+                    <button id="meta-ai-assistant" aria-label="Meta AI business assistant">Meta AI business assistant</button>
+                    <aside id="meta-ai-sidebar" aria-label="Meta AI business assistant sidebar" hidden>
+                        <button id="meta-ai-add-image">Add image</button>
+                    </aside>
+                    <simplified-input-menu id="gemini-menu" data-open="true">
+                        <button id="gemini-upload-files">Upload files</button>
+                    </simplified-input-menu>
+                    <button id="generic-upload-files" type="button">Upload Files</button>
+                    <a id="issue-title-add-image" href="#issue-add-image">Add image fails in editor</a>
+                    <div id="drop-zone">Drag file here</div>
+                    <div id="upload-modal" data-test-modal role="dialog">
+                        <button id="modal-dismiss" aria-label="Dismiss">Dismiss</button>
+                        <button id="modal-menu" class="MmwNPb" aria-label="Menu">Menu</button>
+                        <button id="modal-close" class="UTNHae" aria-label="Close">Close</button>
+                        <button id="modal-reload">Reload</button>
+                        <button id="modal-camera">Take a picture</button>
+                        <div id="modal-body">Upload from computer</div>
+                    </div>
+                    <button id="add-dynamic">Add dynamic input</button>
+                    <div id="dynamic-host"></div>
+                    <iframe id="upload-frame" src="/frame"></iframe>
+                    <output id="changed"></output>
+                    <script>
+                        const plain = document.getElementById('plain');
+                        const labeled = document.getElementById('labeled');
+                        const proxyUpload = document.getElementById('proxy-upload');
+                        const showPickerUpload = document.getElementById('show-picker-upload');
+                        const fsPickerUpload = document.getElementById('fs-picker-upload');
+                        const dropUpload = document.getElementById('drop-upload');
+                        const displayMode = document.getElementById('display-mode');
+                        const deviceUpload = document.getElementById('device-upload-button');
+                        const uploadFromDesktop = document.getElementById('upload-from-desktop');
+                        const redditAddMedia = document.getElementById('reddit-add-media');
+                        const addImage = document.getElementById('add-image');
+                        const businessAddPhoto = document.getElementById('business-add-photo');
+                        const addPhotoVideo = document.getElementById('add-photo-video');
+                        const addVideoDropdown = document.getElementById('add-video-dropdown');
+                        const videoDropdownMenu = document.getElementById('video-dropdown-menu');
+                        const uploadDesktopMenuitem = document.getElementById('upload-desktop-menuitem');
+                        const uploadVideoEditMenuitem = document.getElementById('upload-video-edit-menuitem');
+                        const uploadMenuitemEarlyClose = document.getElementById('upload-menuitem-early-close');
+                        const attachFileIcon = document.getElementById('attach-file-icon');
+                        const metaAiAssistant = document.getElementById('meta-ai-assistant');
+                        const metaAiSidebar = document.getElementById('meta-ai-sidebar');
+                        const metaAiAddImage = document.getElementById('meta-ai-add-image');
+                        const geminiMenu = document.getElementById('gemini-menu');
+                        const geminiUploadFiles = document.getElementById('gemini-upload-files');
+                        const genericUploadFiles = document.getElementById('generic-upload-files');
+                        const issueTitleAddImage = document.getElementById('issue-title-add-image');
+                        const dropZone = document.getElementById('drop-zone');
+                        const addDynamic = document.getElementById('add-dynamic');
+                        const dynamicHost = document.getElementById('dynamic-host');
+                        const changed = document.getElementById('changed');
+                        const cachedInputClick = HTMLInputElement.prototype.click;
+                        window.pasteSeen = false;
+                        window.hostOverlayUploadPrevented = false;
+                        document.addEventListener('paste', () => window.pasteSeen = true);
+                        document.addEventListener('click', event => {
+                            const path = event.composedPath ? event.composedPath() : [];
+                            if (path.some(node => node && node.id === 'cnp-overlay-file-input')) {
+                                window.hostOverlayUploadPrevented = true;
+                                event.preventDefault();
+                            }
+                        }, true);
+                        let displayModeOpen = false;
+                        let geminiMenuOpen = true;
+                        let removeEarlyCloseUploadOnOutsidePointerUp = false;
+                        let businessPointerdownInput = null;
+                        window.openGeminiMenu = () => {
+                            geminiMenuOpen = true;
+                            geminiMenu.dataset.open = 'true';
+                        };
+                        function dynamicUpload(prefix, options = {}) {
+                            const input = document.createElement('input');
+                            input.id = prefix;
+                            input.type = 'file';
+                            input.accept = options.accept || '';
+                            input.multiple = !!options.multiple;
+                            input.style.display = 'none';
+                            document.body.appendChild(input);
+                            input.addEventListener('change', () => {
+                                changed.textContent = prefix + ':' + input.files[0].name;
+                                if (options.reclickAfterChange)
+                                    (options.cachedClick ? cachedInputClick : HTMLInputElement.prototype.click).call(input);
+                            });
+                            (options.cachedClick ? cachedInputClick : HTMLInputElement.prototype.click).call(input);
+                        }
+                        plain.addEventListener('change', () => changed.textContent = 'plain:' + plain.files[0].name);
+                        labeled.addEventListener('change', () => changed.textContent = 'labeled:' + labeled.files[0].name);
+                        proxyUpload.addEventListener('click', () => {
+                            const proxyInput = document.createElement('input');
+                            proxyInput.id = 'proxy';
+                            proxyInput.type = 'file';
+                            proxyInput.style.display = 'none';
+                            document.body.appendChild(proxyInput);
+                            proxyInput.addEventListener('change', () => changed.textContent = 'proxy:' + proxyInput.files[0].name);
+                            proxyInput.click();
+                        });
+                        showPickerUpload.addEventListener('click', () => {
+                            const pickerInput = document.createElement('input');
+                            pickerInput.id = 'picker';
+                            pickerInput.type = 'file';
+                            pickerInput.style.display = 'none';
+                            document.body.appendChild(pickerInput);
+                            pickerInput.addEventListener('change', () => changed.textContent = 'picker:' + pickerInput.files[0].name);
+                            pickerInput.showPicker();
+                        });
+                        fsPickerUpload.addEventListener('click', async () => {
+                            const [handle] = await showOpenFilePicker({ types: [{ accept: { 'text/plain': ['.txt'] } }] });
+                            const file = await handle.getFile();
+                            changed.textContent = 'fs:' + file.name;
+                        });
+                        dropUpload.addEventListener('click', event => {
+                            event.preventDefault();
+                            changed.textContent = 'drop-upload:clicked';
+                        });
+                        displayMode.addEventListener('click', () => {
+                            displayModeOpen = !displayModeOpen;
+                            changed.textContent = 'display:' + displayModeOpen;
+                        });
+                        deviceUpload.addEventListener('click', () => dynamicUpload('reddit-device', { accept: 'image/*' }));
+                        uploadFromDesktop.addEventListener('click', () => dynamicUpload('upload-desktop'));
+                        redditAddMedia.addEventListener('click', () => dynamicUpload('reddit-add-media', { accept: 'image/*' }));
+                        addImage.addEventListener('click', () => {
+                            const input = document.createElement('input');
+                            input.id = 'bsky-image';
+                            input.type = 'file';
+                            input.accept = 'image/*';
+                            input.style.display = 'none';
+                            document.body.appendChild(input);
+                            input.addEventListener('change', () => {
+                                changed.textContent = 'bsky-image:' + input.files[0].name;
+                                cachedInputClick.call(input);
+                            });
+                            setTimeout(() => cachedInputClick.call(input), 0);
+                        });
+                        businessAddPhoto.addEventListener('pointerdown', () => {
+                            businessPointerdownInput = document.createElement('input');
+                            businessPointerdownInput.id = 'business-add-photo';
+                            businessPointerdownInput.type = 'file';
+                            businessPointerdownInput.accept = 'image/*';
+                            businessPointerdownInput.style.display = 'none';
+                            document.body.appendChild(businessPointerdownInput);
+                            businessPointerdownInput.addEventListener('change', () => changed.textContent = 'business-add-photo:' + businessPointerdownInput.files[0].name);
+                        });
+                        businessAddPhoto.addEventListener('click', () => setTimeout(() => cachedInputClick.call(businessPointerdownInput), 0));
+                        addPhotoVideo.addEventListener('click', () => dynamicUpload('facebook-photo-video', { accept: 'image/*,video/*' }));
+                        addVideoDropdown.addEventListener('click', () => {
+                            const expanded = addVideoDropdown.getAttribute('aria-expanded') === 'true';
+                            addVideoDropdown.setAttribute('aria-expanded', String(!expanded));
+                            videoDropdownMenu.hidden = expanded;
+                            changed.textContent = 'video-menu:' + !expanded;
+                        });
+                        uploadDesktopMenuitem.addEventListener('click', () => dynamicUpload('upload-desktop-menuitem'));
+                        uploadVideoEditMenuitem.addEventListener('click', () => dynamicUpload('upload-video-edit-menuitem', { accept: 'video/*' }));
+                        uploadMenuitemEarlyClose.addEventListener('pointerdown', () => removeEarlyCloseUploadOnOutsidePointerUp = true);
+                        uploadMenuitemEarlyClose.addEventListener('click', () => dynamicUpload('upload-menuitem-early-close', { accept: 'image/*' }));
+                        attachFileIcon.addEventListener('click', () => dynamicUpload('attach-file-icon'));
+                        metaAiAssistant.addEventListener('click', () => {
+                            metaAiSidebar.hidden = false;
+                            changed.textContent = 'meta-ai-sidebar:true';
+                        });
+                        metaAiAddImage.addEventListener('click', () => dynamicUpload('meta-ai-add-image', { accept: 'image/*' }));
+                        geminiUploadFiles.addEventListener('click', () => {
+                            if (geminiMenuOpen)
+                                dynamicUpload('gemini-upload-files', { multiple: true });
+                        });
+                        genericUploadFiles.addEventListener('click', () => changed.textContent = 'generic-upload-files:clicked');
+                        issueTitleAddImage.addEventListener('click', event => {
+                            event.preventDefault();
+                            changed.textContent = 'issue-title-add-image:clicked';
+                        });
+                        document.addEventListener('click', event => {
+                            if (geminiMenuOpen && !geminiMenu.contains(event.target)) {
+                                geminiMenuOpen = false;
+                                geminiMenu.dataset.open = 'false';
+                            }
+                        });
+                        document.addEventListener('pointerup', event => {
+                            if (removeEarlyCloseUploadOnOutsidePointerUp && !videoDropdownMenu.hidden && !videoDropdownMenu.contains(event.target) && !addVideoDropdown.contains(event.target))
+                                uploadMenuitemEarlyClose.remove();
+                        });
+                        dropZone.addEventListener('dragover', event => event.preventDefault());
+                        dropZone.addEventListener('drop', event => {
+                            event.preventDefault();
+                            changed.textContent = 'drop:' + event.dataTransfer.files[0].name;
+                        });
+                        addDynamic.addEventListener('click', () => {
+                            const dynamic = document.createElement('input');
+                            dynamic.id = 'dynamic';
+                            dynamic.type = 'file';
+                            dynamicHost.appendChild(dynamic);
+                            dynamic.addEventListener('change', () => changed.textContent = 'dynamic:' + dynamic.files[0].name);
+                        });
+                    </script>
+                </body>
+            </html>`,
+        '/frame': `<!doctype html>
+            <html>
+                <body>
+                    <input id="framed" type="file">
+                    <output id="frame-changed"></output>
+                    <script>
+                        const framed = document.getElementById('framed');
+                        const frameChanged = document.getElementById('frame-changed');
+                        framed.addEventListener('change', () => frameChanged.textContent = 'frame:' + framed.files[0].name);
+                    </script>
+                </body>
+            </html>`
+    };
+
+    const server = http.createServer((request, response) => {
+        response.setHeader('Content-Type', 'text/html; charset=utf-8');
+        response.end(pages[request.url] || pages['/']);
+    });
+
+    return new Promise(resolve => {
+        server.listen(0, '127.0.0.1', () => resolve({
+            server,
+            url: `http://127.0.0.1:${server.address().port}/`
+        }));
+    });
+}
+
+test('extension overlay supports upload targets without exposing paste message bridge', async () => {
+    const extensionPath = path.resolve(__dirname, '..', 'dist', 'chromium');
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cnp-smoke-'));
+    const uploadFile = path.join(os.tmpdir(), 'cnp-smoke-upload.txt');
+    fs.writeFileSync(uploadFile, 'copy-n-paste smoke upload');
+
+    const { server, url } = await startServer();
+    const context = await chromium.launchPersistentContext(userDataDir, {
+        headless: false,
+        viewport: null,
+        args: [
+            `--disable-extensions-except=${extensionPath}`,
+            `--load-extension=${extensionPath}`
+        ]
+    });
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: new URL(url).origin });
+
+    try {
+        const page = await context.newPage();
+        await page.goto(url);
+        await page.waitForFunction(() => document.querySelector('#plain')?.dataset.cnpCreateListener === 'true');
+        await page.waitForFunction(() => document.documentElement.dataset.cnpInitLoaded === 'true');
+        await page.waitForFunction(() => document.documentElement.dataset.cnpPageHookLoaded === 'true');
+        await writeClipboardImage(page);
+
+        await page.evaluate(() => window.postMessage({ Type: 'paste' }, '*'));
+        await page.waitForTimeout(250);
+        await expect.poll(() => page.evaluate(() => window.pasteSeen)).toBe(false);
+
+        await page.locator('#plain').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-image-preview')).toBeVisible();
+        await page.locator('#cnp-preview-container').click();
+        await expect(page.locator('#changed')).toContainText('plain:CnP_');
+
+        await page.locator('#label-upload').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-upload-btn')).toBeVisible();
+        await page.locator('#cnp-overlay-file-input').setInputFiles(uploadFile);
+        await expect(page.locator('#changed')).toHaveText('labeled:cnp-smoke-upload.txt');
+
+        await page.locator('#proxy-upload').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-upload-btn')).toBeVisible();
+        await page.locator('#cnp-overlay-file-input').setInputFiles(uploadFile);
+        await expect(page.locator('#changed')).toHaveText('proxy:cnp-smoke-upload.txt');
+
+        await page.locator('#show-picker-upload').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-upload-btn')).toBeVisible();
+        await page.locator('#cnp-overlay-file-input').setInputFiles(uploadFile);
+        await expect(page.locator('#changed')).toHaveText('picker:cnp-smoke-upload.txt');
+
+        await page.locator('#fs-picker-upload').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-upload-btn')).toBeVisible();
+        await page.locator('#cnp-overlay-file-input').setInputFiles(uploadFile);
+        await expect(page.locator('#changed')).toHaveText('fs:cnp-smoke-upload.txt');
+
+        for (const selector of ['#modal-dismiss', '#modal-menu', '#modal-close', '#modal-reload', '#modal-camera', '#modal-body', '#upload-modal']) {
+            await page.locator(selector).click();
+            await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        }
+
+        await page.locator('#display-mode').click();
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        await expect(page.locator('#changed')).toHaveText('display:true');
+
+        await page.locator('#generic-upload-files').click();
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        await expect(page.locator('#changed')).toHaveText('generic-upload-files:clicked');
+
+        await page.locator('#issue-title-add-image').click();
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        await expect(page.locator('#changed')).toHaveText('issue-title-add-image:clicked');
+
+        await page.locator('#add-video-dropdown').click();
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        await expect(page.locator('#video-dropdown-menu')).toBeVisible();
+
+        for (const target of [
+            { selector: '#device-upload-button', output: 'reddit-device' },
+            { selector: '#upload-from-desktop', output: 'upload-desktop' },
+            { selector: '#reddit-add-media', output: 'reddit-add-media' },
+            { selector: '#business-add-photo', output: 'business-add-photo' },
+            { selector: '#add-photo-video', output: 'facebook-photo-video' },
+            { selector: '#upload-desktop-menuitem', output: 'upload-desktop-menuitem' },
+            { selector: '#upload-video-edit-menuitem', output: 'upload-video-edit-menuitem' },
+            { selector: '#upload-menuitem-early-close', output: 'upload-menuitem-early-close' },
+            { selector: '#attach-file-icon', output: 'attach-file-icon' }
+        ]) {
+            await writeClipboardImage(page);
+            await page.locator(target.selector).click();
+            await expect(page.locator('.cnp-overlay-content'), `${target.selector} should show overlay`).toBeVisible();
+            await expect(page.locator('#cnp-image-preview'), `${target.selector} should show preview`).toBeVisible();
+            await page.locator('#cnp-preview-container').click();
+            await expect(page.locator('#changed'), `${target.selector} should receive preview file`).toContainText(`${target.output}:CnP_`);
+            await expect(page.locator('.cnp-overlay-content'), `${target.selector} should close overlay`).toHaveCount(0);
+        }
+
+        await page.locator('#meta-ai-assistant').click();
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        await expect(page.locator('#meta-ai-sidebar')).toBeVisible();
+
+        await writeClipboardImage(page);
+        await page.locator('#meta-ai-add-image').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-image-preview')).toBeVisible();
+        await page.locator('#cnp-preview-container').click();
+        await expect(page.locator('#changed')).toContainText('meta-ai-add-image:CnP_');
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+
+        await writeClipboardImage(page);
+        await page.locator('#add-image').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-image-preview')).toBeVisible();
+        const unexpectedBskyChooser = page.waitForEvent('filechooser', { timeout: 1000 }).then(() => 'filechooser').catch(() => null);
+        await page.locator('#cnp-preview-container').click();
+        await expect(page.locator('#changed')).toContainText('bsky-image:CnP_');
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        await expect.poll(() => unexpectedBskyChooser).toBe(null);
+
+        const previousBskyAttachment = await page.locator('#changed').innerText();
+        await page.locator('#add-image').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#changed')).toHaveText(previousBskyAttachment);
+        await expect(page.locator('#cnp-overlay-file-input')).toBeVisible();
+        await expect.poll(() => page.locator('#cnp-upload-btn').evaluate(uploadButton => {
+            const rect = uploadButton.getBoundingClientRect();
+            const hitTarget = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+            return !!(hitTarget && hitTarget.id === 'cnp-overlay-file-input' && hitTarget.type === 'file');
+        })).toBe(true);
+        const bskyChooserPromise = page.waitForEvent('filechooser');
+        await page.locator('#cnp-upload-btn').click();
+        const bskyChooser = await bskyChooserPromise;
+        await bskyChooser.setFiles(uploadFile);
+        await expect.poll(() => page.evaluate(() => window.hostOverlayUploadPrevented)).toBe(false);
+        await expect(page.locator('#changed')).toHaveText('bsky-image:cnp-smoke-upload.txt');
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+
+        for (const target of [
+            { selector: '#add-photo-video', output: 'facebook-photo-video' }
+        ]) {
+            await page.locator(target.selector).click();
+            await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+            const nativeChooserPromise = page.waitForEvent('filechooser');
+            await page.locator('#cnp-upload-btn').click();
+            const nativeChooser = await nativeChooserPromise;
+            await nativeChooser.setFiles(uploadFile);
+            await expect(page.locator('#changed')).toHaveText(`${target.output}:cnp-smoke-upload.txt`);
+            await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        }
+
+        await page.evaluate(() => window.openGeminiMenu());
+        await page.locator('#gemini-upload-files').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-overlay-file-input')).toBeVisible();
+        await expect.poll(() => page.locator('#cnp-upload-btn').evaluate(uploadButton => {
+            const rect = uploadButton.getBoundingClientRect();
+            const hitTarget = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+            return !!(hitTarget && hitTarget.id === 'cnp-overlay-file-input' && hitTarget.type === 'file');
+        })).toBe(true);
+        const overlayFileChooserPromise = page.waitForEvent('filechooser');
+        await page.locator('#cnp-upload-btn').click();
+        const overlayFileChooser = await overlayFileChooserPromise;
+        await overlayFileChooser.setFiles(uploadFile);
+        await expect.poll(() => page.evaluate(() => window.hostOverlayUploadPrevented)).toBe(false);
+        await expect(page.locator('#changed')).toHaveText('gemini-upload-files:cnp-smoke-upload.txt');
+        await expect(page.locator('#gemini-menu')).toHaveAttribute('data-open', 'true');
+
+        await page.locator('#drop-upload').click();
+        await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+        await expect(page.locator('#changed')).toHaveText('drop-upload:clicked');
+
+        await page.locator('#add-dynamic').dispatchEvent('click');
+        await page.waitForFunction(() => document.querySelector('#dynamic')?.dataset.cnpCreateListener === 'true');
+        await page.locator('#dynamic').click();
+        await expect(page.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(page.locator('#cnp-upload-btn')).toBeVisible();
+        await page.locator('#cnp-overlay-file-input').setInputFiles(uploadFile);
+        await expect(page.locator('#changed')).toHaveText('dynamic:cnp-smoke-upload.txt');
+
+        const frame = page.frameLocator('#upload-frame');
+        await frame.locator('#framed').click();
+        await expect(frame.locator('.cnp-overlay-content')).toBeVisible();
+        await expect(frame.locator('#cnp-upload-btn')).toBeVisible();
+        await frame.locator('#cnp-overlay-file-input').setInputFiles(uploadFile);
+        await expect(frame.locator('#frame-changed')).toHaveText('frame:cnp-smoke-upload.txt');
+    } finally {
+        await context.close();
+        server.close();
+        fs.rmSync(userDataDir, { recursive: true, force: true });
+        fs.rmSync(uploadFile, { force: true });
+    }
+});

--- a/tests/real-sites.spec.js
+++ b/tests/real-sites.spec.js
@@ -1,0 +1,364 @@
+const { test, expect, chromium } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const extensionPath = path.join(rootDir, 'dist', 'chromium');
+const profileDir = path.resolve(process.env.CNP_PROFILE_DIR || path.join(rootDir, 'playwright-profiles', 'real-sites'));
+const browserChannel = process.env.CNP_BROWSER_CHANNEL || '';
+const selectedTargets = new Set((process.env.CNP_SITE_TARGETS || 'contacts,linkedin,bsky,gemini')
+    .split(/[\s,]+/)
+    .map(target => target.trim().toLowerCase())
+    .filter(Boolean));
+
+function shouldRun(target) {
+    return selectedTargets.has('all') || selectedTargets.has(target);
+}
+
+function launchOptions() {
+    const options = {
+        headless: false,
+        ignoreDefaultArgs: ['--enable-automation'],
+        args: [
+            '--disable-blink-features=AutomationControlled',
+            `--disable-extensions-except=${extensionPath}`,
+            `--load-extension=${extensionPath}`
+        ]
+    };
+
+    if (browserChannel)
+        options.channel = browserChannel;
+
+    return options;
+}
+
+async function waitForExtension(page) {
+    await page.waitForFunction(() => document.documentElement.dataset.cnpInitLoaded === 'true', null, { timeout: 15000 });
+    await page.waitForFunction(() => document.documentElement.dataset.cnpPageHookLoaded === 'true', null, { timeout: 15000 });
+}
+
+async function waitForFrame(page, urlPattern, timeout = 30000) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        const frame = page.frames().find(candidate => urlPattern.test(candidate.url()));
+        if (frame)
+            return frame;
+
+        await page.waitForTimeout(250);
+    }
+
+    throw new Error(`Frame matching ${urlPattern} was not found`);
+}
+
+async function skipIfLoginRequired(page, loginPattern, message) {
+    await page.waitForLoadState('domcontentloaded').catch(() => { });
+    test.skip(loginPattern.test(page.url()), message);
+}
+
+async function clickAndDetectUpload(page, locator, label, overlayScope = page) {
+    const overlay = overlayScope.locator('.cnp-overlay-content').first();
+    const fileChooserPromise = page.waitForEvent('filechooser', { timeout: 7000 })
+        .then(() => 'filechooser')
+        .catch(() => null);
+    const clickPromise = locator.click({ timeout: 15000 })
+        .then(() => null)
+        .catch(error => error);
+
+    const earlyResult = await Promise.race([clickPromise, fileChooserPromise]);
+    if (earlyResult === 'filechooser')
+        return 'filechooser';
+    if (earlyResult instanceof Error)
+        throw new Error(`${label} click failed: ${earlyResult.message}`);
+
+    const overlayPromise = overlay.waitFor({ state: 'visible', timeout: 7000 })
+        .then(() => 'overlay')
+        .catch(() => null);
+    const finalResult = await Promise.race([overlayPromise, fileChooserPromise]);
+
+    return finalResult || 'no-overlay';
+}
+
+async function expectUploadOverlay(page, locator, label, overlayScope = page) {
+    let result = 'no-overlay';
+    for (let attempt = 0; attempt < 3; attempt++) {
+        result = await clickAndDetectUpload(page, locator, label, overlayScope);
+        expect(result, `${label} opened the native file chooser instead of the CnP overlay`).not.toBe('filechooser');
+        if (result === 'overlay')
+            return;
+
+        await page.waitForTimeout(750);
+    }
+
+    expect(result, `${label} did not show the CnP overlay`).toBe('overlay');
+}
+
+async function closeOverlay(scope) {
+    await scope.evaluate(() => document.querySelectorAll('.cnp-overlay').forEach(overlay => overlay.remove()));
+}
+
+async function waitForNoFileChooser(page, action, timeout = 2500) {
+    const fileChooserPromise = page.waitForEvent('filechooser', { timeout })
+        .then(() => 'filechooser')
+        .catch(() => null);
+
+    await action();
+    expect(await fileChooserPromise, 'A native file chooser opened unexpectedly').toBeNull();
+}
+
+async function expectOverlayUploadDirectFileInput(page) {
+    await expect(page.locator('#cnp-upload-btn')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#cnp-overlay-file-input')).toBeVisible({ timeout: 10000 });
+    const directInputHitTarget = await page.locator('#cnp-upload-btn').evaluate(uploadButton => {
+        const rect = uploadButton.getBoundingClientRect();
+        const hitTarget = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        return !!(hitTarget && hitTarget.id === 'cnp-overlay-file-input' && hitTarget.type === 'file');
+    });
+    expect(directInputHitTarget, 'The Upload Files row is not covered by the real overlay file input').toBe(true);
+}
+
+async function waitForAnyLocator(page, locators, timeout = 30000) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        for (const locator of locators) {
+            if (await locator.first().isVisible().catch(() => false))
+                return locator.first();
+        }
+
+        await page.waitForTimeout(250);
+    }
+
+    throw new Error('None of the expected locators became visible');
+}
+
+async function isActionable(locator) {
+    if (!await locator.isVisible({ timeout: 250 }).catch(() => false))
+        return false;
+
+    return locator.evaluate(element => {
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return rect.width > 0
+            && rect.height > 0
+            && style.display !== 'none'
+            && style.visibility !== 'hidden'
+            && !element.disabled
+            && element.getAttribute('aria-disabled') !== 'true';
+    }).catch(() => false);
+}
+
+async function waitForAnyActionableLocator(page, locators, label, timeout = 30000) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        for (const locator of locators) {
+            const candidate = locator.first();
+            if (await isActionable(candidate))
+                return candidate;
+        }
+
+        await page.waitForTimeout(250);
+    }
+
+    throw new Error(`${label} did not become actionable`);
+}
+
+async function waitForActionableLocator(page, locator, label, timeout = 30000) {
+    return waitForAnyActionableLocator(page, [locator], label, timeout);
+}
+
+async function waitForBskyAddImageButton(page) {
+    const addImageButton = page.locator('button[aria-label="Add image"]').first();
+    const newPostButton = page.getByRole('button', { name: /^(new post|compose)$/i }).first();
+    const firstControl = await waitForAnyActionableLocator(page, [addImageButton, newPostButton], 'Bsky composer controls', 30000).catch(() => null);
+    test.skip(!firstControl, 'Bsky profile is not signed in or the composer controls are not visible. Run `npm run diagnose:sites -- bsky` and log in manually first.');
+
+    if (!await isActionable(addImageButton))
+        await firstControl.click();
+
+    return waitForActionableLocator(page, addImageButton, 'Bsky Add image', 30000);
+}
+
+async function waitForGeminiUploadFiles(page) {
+    const uploadFiles = page.getByText(/^Upload files$/i).first();
+    const menuControls = [
+        page.locator('simplified-input-menu button').first(),
+        page.getByRole('button', { name: /add|attach|upload|files/i }).first()
+    ];
+    const deadline = Date.now() + 30000;
+
+    while (Date.now() < deadline) {
+        if (await isActionable(uploadFiles))
+            return uploadFiles;
+
+        const menuControl = await waitForAnyActionableLocator(page, menuControls, 'Gemini upload menu control', 1500).catch(() => null);
+        if (menuControl)
+            await menuControl.click().catch(() => { });
+
+        await page.waitForTimeout(500);
+    }
+
+    test.skip(true, 'Gemini upload menu was not visible or actionable. Run `npm run diagnose:sites -- gemini` and open the prompt controls manually first.');
+}
+
+async function writeClipboardTestImage(page) {
+    await page.bringToFront();
+    await page.locator('body').click({ position: { x: 20, y: 20 } }).catch(() => { });
+    await page.evaluate(async () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 160;
+        canvas.height = 160;
+
+        const context = canvas.getContext('2d');
+        context.fillStyle = '#2f7cff';
+        context.fillRect(0, 0, 160, 160);
+        context.fillStyle = '#ffffff';
+        context.fillRect(40, 40, 80, 80);
+
+        const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+    });
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('authenticated real-site upload controls', () => {
+    test.setTimeout(90000);
+
+    let context;
+
+    test.beforeAll(async () => {
+        if (!fs.existsSync(path.join(extensionPath, 'manifest.json')))
+            throw new Error('Missing dist/chromium/manifest.json. Run `npm run build` before `npm run test:sites`.');
+
+        fs.mkdirSync(profileDir, { recursive: true });
+        context = await chromium.launchPersistentContext(profileDir, launchOptions());
+    });
+
+    test.afterAll(async () => {
+        await context?.close();
+    });
+
+    if (shouldRun('contacts')) {
+        test('Google Contacts contact photo preview reaches crop dialog', async () => {
+            const page = await context.newPage();
+            await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: 'https://contacts.google.com' });
+            await page.goto('https://contacts.google.com/new', { waitUntil: 'domcontentloaded' });
+            await skipIfLoginRequired(page, /accounts\.google\.com/, 'Google Contacts profile is not signed in. Run `npm run diagnose:sites -- contacts` and log in manually first.');
+            await waitForExtension(page);
+            await writeClipboardTestImage(page);
+
+            const setPhotoButton = page.getByRole('button', { name: /set contact photo/i }).first();
+            await expect(setPhotoButton).toBeVisible({ timeout: 30000 });
+
+            await setPhotoButton.click();
+            const photoFrame = await waitForFrame(page, /myaccount\.google\.com\/profile-picture/);
+            await photoFrame.waitForFunction(() => document.documentElement.dataset.cnpInitLoaded === 'true', null, { timeout: 15000 });
+            await photoFrame.waitForFunction(() => document.documentElement.dataset.cnpPageHookLoaded === 'true', null, { timeout: 15000 });
+
+            const fromComputerTab = photoFrame.getByRole('tab', { name: /from computer/i });
+            await expect(fromComputerTab).toBeVisible({ timeout: 30000 });
+            await fromComputerTab.click();
+
+            const uploadButton = photoFrame.getByRole('button', { name: /upload from computer/i });
+            await expect(uploadButton).toBeVisible({ timeout: 30000 });
+            await expectUploadOverlay(page, uploadButton, 'Google Contacts Upload from computer', photoFrame);
+            await expect(photoFrame.locator('#cnp-image-preview')).toBeVisible({ timeout: 10000 });
+            await photoFrame.locator('#cnp-preview-container').click();
+            await page.waitForTimeout(750);
+            await expect.poll(() => photoFrame.url(), { timeout: 30000 }).toMatch(/\/profile-picture\/crop\//);
+            await expect(photoFrame.getByText(/crop & rotate/i).first()).toBeVisible({ timeout: 30000 });
+            await page.close();
+        });
+    }
+
+    if (shouldRun('bsky')) {
+        test('Bsky Add image preview attaches without opening native picker', async () => {
+            const page = await context.newPage();
+            await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: 'https://bsky.app' });
+            await page.goto('https://bsky.app/', { waitUntil: 'domcontentloaded' });
+            await waitForExtension(page);
+
+            const addImageButton = await waitForBskyAddImageButton(page);
+            await writeClipboardTestImage(page);
+            await expectUploadOverlay(page, addImageButton, 'Bsky Add image');
+            await expect(page.locator('#cnp-image-preview')).toBeVisible({ timeout: 10000 });
+            await waitForNoFileChooser(page, () => page.locator('#cnp-preview-container').click(), 3000);
+            await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+            await page.close();
+        });
+
+        test('Bsky Add image Upload Files opens CnP picker and attaches', async () => {
+            const page = await context.newPage();
+            const uploadFile = path.join(rootDir, 'test-results', 'cnp-bsky-upload.png');
+            fs.mkdirSync(path.dirname(uploadFile), { recursive: true });
+            fs.writeFileSync(uploadFile, Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAKAAAACgCAIAAAAErfB6AAABHklEQVR4nO3RsQ3AMAwEwYz77+wuQEuYFhQcZqWfubc9AAAAAAAAAAAAwDy7ewH8DBJgQECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAGCV9wdDKDnPD0DBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBPgCk8oC+nY8vl8AAAAASUVORK5CYII=', 'base64'));
+
+            await page.goto('https://bsky.app/', { waitUntil: 'domcontentloaded' });
+            await waitForExtension(page);
+
+            const addImageButton = await waitForBskyAddImageButton(page);
+            await expectUploadOverlay(page, addImageButton, 'Bsky Add image');
+            await expectOverlayUploadDirectFileInput(page);
+            const chooserPromise = page.waitForEvent('filechooser', { timeout: 10000 });
+            await page.locator('#cnp-upload-btn').click();
+            const chooser = await chooserPromise;
+            await chooser.setFiles(uploadFile);
+            await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+            await fs.promises.rm(uploadFile, { force: true });
+            await page.close();
+        });
+    }
+
+    if (shouldRun('gemini')) {
+        test('Gemini Upload files keeps menu open and opens native chooser', async () => {
+            const page = await context.newPage();
+            const uploadFile = path.join(rootDir, 'test-results', 'cnp-gemini-upload.txt');
+            fs.mkdirSync(path.dirname(uploadFile), { recursive: true });
+            fs.writeFileSync(uploadFile, 'copy-n-paste Gemini upload test');
+
+            await page.goto('https://gemini.google.com/app', { waitUntil: 'domcontentloaded' });
+            await skipIfLoginRequired(page, /accounts\.google\.com/, 'Gemini profile is not signed in. Run `npm run diagnose:sites -- gemini` and log in manually first.');
+            await waitForExtension(page);
+
+            const uploadFiles = await waitForGeminiUploadFiles(page);
+            await expectUploadOverlay(page, uploadFiles, 'Gemini Upload files');
+            await expectOverlayUploadDirectFileInput(page);
+            const chooserPromise = page.waitForEvent('filechooser', { timeout: 10000 });
+            await page.locator('#cnp-upload-btn').click();
+            const chooser = await chooserPromise;
+            expect(chooser, 'Gemini Upload Files did not open a native file chooser').toBeTruthy();
+            await chooser.setFiles(uploadFile);
+            await expect(page.locator('.cnp-overlay-content')).toHaveCount(0);
+            await page.getByText(path.basename(uploadFile)).first().waitFor({ state: 'visible', timeout: 15000 }).catch(() => { });
+            await fs.promises.rm(uploadFile, { force: true });
+            await page.close();
+        });
+    }
+
+    if (shouldRun('linkedin')) {
+        test('LinkedIn photo upload shows CnP overlay', async () => {
+            const page = await context.newPage();
+            await page.goto('https://www.linkedin.com/', { waitUntil: 'domcontentloaded' });
+            await skipIfLoginRequired(page, /linkedin\.com\/(login|uas\/login|checkpoint)/, 'LinkedIn profile is not signed in. Run `npm run diagnose:sites -- linkedin` and log in manually first.');
+            await page.waitForURL(/linkedin\.com\/(feed|in|mynetwork|jobs|notifications|messaging|$)/, { timeout: 30000 }).catch(() => { });
+            await waitForExtension(page);
+
+            const photoControl = page.getByRole('button', { name: /^(Photo|Foto)$/i }).first();
+            await expect(photoControl).toBeVisible({ timeout: 30000 });
+
+            const firstResult = await clickAndDetectUpload(page, photoControl, 'LinkedIn Photo');
+            expect(firstResult, 'LinkedIn Photo opened the native file chooser instead of the CnP overlay').not.toBe('filechooser');
+            if (firstResult === 'overlay') {
+                await closeOverlay(page);
+                await page.close();
+                return;
+            }
+
+            const uploadControl = page.locator('.media-editor-file-selector__upload-media-button, label.artdeco-button').first();
+            const uploadControlVisible = await uploadControl.isVisible({ timeout: 15000 }).catch(() => false);
+            test.skip(!uploadControlVisible, 'LinkedIn did not expose the media upload composer in this automated session. Verify with `npm run diagnose:sites -- linkedin`.');
+            await expectUploadOverlay(page, uploadControl, 'LinkedIn Upload from computer');
+            await closeOverlay(page);
+            await page.close();
+        });
+    }
+});


### PR DESCRIPTION
<h3>Resolves #28, #30, #41, #5, possibly #34, #40 (feedback from testers appreciated)</h3>

**Injection & Permissions**
- Switch Chromium page-world injection to `chrome.scripting.executeScript({ world: 'MAIN' })` as the primary path, with a script-tag fallback only when necessary.
- Add `host_permissions` to the MV3 manifest to allow scripting across all frames without requiring visible `<script>` injection.

**Pickerless Upload Handling**
- Stores selected files briefly and replays them into dynamically created file inputs (e.g. Google Contacts).
- Ensures newly created or cached inputs are fulfilled before native picker fallback triggers.
- Improves reliability across synthetic drag/drop, `input.click()`, and dynamic DOM flows.

**Overlay Interaction Improvements**
- Make the overlay file input the direct click target to ensure native picker activation.
- Attach replay on pointerdown with click fallback for early teardown flows (e.g. M365 menu behavior).
- Add capture-phase containment to prevent host-page listeners from canceling picker activation.
- Allow overlay to be created again on second click of the input if overlay still exists (undoes workaround https://github.com/kazcfz/Copy-n-Paste/pull/37)

**Native Behavior Enhancements**
- Convert wrapped APIs (`showOpenFilePicker`, `HTMLElement.click`, `HTMLInputElement.click`, `showPicker`) to method-style functions without own prototype properties.
- Mirror native function characteristics (name, length, toString) via a WeakMap-backed override.

**Stability & Fixes**
- Add coordination between page and isolated worlds to prevent duplicate overlay reopen loops.
- Preserve existing upload flows while fixing regressions in Bsky and Gemini manual picker behavior.
- Improve detection of upload actions by distinguishing menu items from trigger controls.
- Remove temporary Google profile-picture guard.
- Preserve existing files only for multi-file inputs.

<br><br>
<h3>Addresses #39 (pending Mozilla review)</h3>

- Replace document-level paste handling with a scoped `<div>` element.
- Remove `contentEditable` + `execCommand` usage to avoid exposing clipboard data in the DOM.
- Restrict paste handling to extension-triggered flows and immediately clear/remove the element after use.
- Add Firefox `data_collection_permissions: none` disclosure and bump minimum Gecko version.

<br><br>
<h3>Test-related</h3>

- Add smoke test suite covering file inputs, `showPicker`, `showOpenFilePicker`,
  pickerless uploads, dynamic inputs, and iframe scenarios
- Add real-site tests for Google Contacts and LinkedIn with authenticated flows
- Expand coverage for Bsky/Gemini cached-click and reclick-after-change patterns
- Add hostile capture-listener checks to verify upload activation cannot be blocked
- Improve Playwright reliability with actionable-locator waits
- Add diagnostics tool with instrumentation, telemetry, and manual-step logging
- Introduce CNP_INTERCEPT_FILE_CHOOSER toggle for native picker mode
- Add npm scripts for test execution and diagnostics
- Move detailed testing documentation to TESTING.md and simplify README